### PR TITLE
Refine single-GPU training workflows and add gradient checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,76 @@
 # LearnRLHF
+
+This repository contains a compact reference implementation of supervised fine-tuning (SFT) and PPO-based reinforcement learning from human feedback (RLHF) for GPT-style language models.
+
+## Hardware guidance
+
+The table below estimates the memory required to train members of the GPT-2 family on a single NVIDIA RTX 4090 (24 GB). Parameter memory assumes mixed-precision training with AdamW, which typically stores weights, gradients, and two FP32 optimizer moments (~12 bytes per parameter). An additional 2–4 GB is usually needed for activations, temporary buffers, and dataloader queues.
+
+| Model        | Parameters | AdamW state (≈12 B/param) | Estimated total VRAM need |
+|--------------|------------|---------------------------|---------------------------|
+| GPT-2        | 124 M      | ≈1.4 GB                  | <4 GB                     |
+| GPT-2 Medium | 355 M      | ≈4.0 GB                  | ~6–8 GB                  |
+| GPT-2 Large  | 774 M      | ≈8.7 GB                  | ~12–14 GB                |
+| GPT-2 XL     | 1.558 B    | ≈17.4 GB                 | ~21–23 GB                |
+
+With careful configuration (batch sizes of 1–2, sequence lengths ≤1024, activation checkpointing, and mixed precision), GPT-2 XL is typically the largest GPT-2 variant that fits within 24 GB while leaving a couple of gigabytes for activations and CUDA overhead. Larger effective batch sizes can be achieved with gradient accumulation.
+
+## Supervised fine-tuning
+
+`train_sft.py` now exposes a `train_sft` function and uses simple module-level constants instead of `argparse`.
+
+```python
+from train_sft import train_sft
+
+train_sft(
+    "data/sft_train.jsonl",
+    out_dir="weights",
+    batch_size=4,
+    lr=5e-5,
+    epochs=1,
+    accum=1,
+    warmup=100,
+    init_path=None,
+    dropout=0.0,
+)
+```
+
+Running `python train_sft.py` will execute the same routine using the constants defined under the `if __name__ == "__main__"` guard—update them before launching training.
+
+## PPO-based RLHF
+
+`train_ppo.py` provides a `train_ppo` function configured in the same style. You can either import and call it directly:
+
+```python
+from train_ppo import train_ppo
+
+train_ppo(
+    "data/preferences_train.jsonl",
+    sft_path="weights/sft_epoch_1.pt",
+    out_dir="ppo_weights",
+    dropout=0.0,
+    rm_batch=4,
+    rm_epochs=1,
+    rm_lr=1e-5,
+    ppo_batch=4,
+    ppo_epochs=1,
+    ppo_steps=4,
+    max_new=64,
+    ppo_lr=1e-5,
+    clip=0.2,
+    kl_coef=0.1,
+    entropy_coef=0.01,
+)
+```
+
+or edit the constants at the bottom of `train_ppo.py` and run `python train_ppo.py`.
+
+Both training scripts now assume single-GPU execution. Gradient accumulation is available through the `accum` (SFT) and `ppo_steps` parameters.
+
+## Testing
+
+Unit tests (including gradient checks for both the SFT loss and the PPO policy objective) can be run with:
+
+```bash
+pytest
+```

--- a/tests/test_ppo.py
+++ b/tests/test_ppo.py
@@ -3,12 +3,14 @@ import sys
 
 import torch
 import torch.nn.functional as F
+from torch.autograd import gradcheck
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
 sys.path.append(ROOT)
 
 from gpt import GPTConfig, GPT
 from train_ppo import ScalarHead, PPOTrainer, gather_log_probs
+from train_ppo import train_ppo  # noqa: F401  # ensure module imports without argparse
 
 
 def build_models():
@@ -67,3 +69,43 @@ def test_ppo_step_runs():
     metrics = trainer.train_step(data)
     assert "policy_loss" in metrics
     assert "value_loss" in metrics
+
+
+def test_ppo_policy_loss_gradcheck():
+    torch.manual_seed(0)
+    config, policy, reference, value, reward = build_models()
+    trainer = PPOTrainer(policy, reference, value, reward, pad_token=0, lr=1e-4)
+
+    batch = 1
+    prompt_len = 2
+    response_len = 3
+    vocab = config.vocab_size
+
+    log_probs = torch.randn(
+        batch, prompt_len + response_len, vocab, dtype=torch.double, requires_grad=True
+    )
+    ref_log_probs = torch.randn(batch, prompt_len + response_len, vocab, dtype=torch.double)
+    responses = torch.randint(0, vocab, (batch, response_len), dtype=torch.long)
+    prompt_lengths = torch.tensor([prompt_len], dtype=torch.double)
+    response_lengths = torch.tensor([response_len], dtype=torch.double)
+    responses_mask = torch.ones(batch, response_len, dtype=torch.double)
+    full_response_mask = torch.zeros(batch, prompt_len + response_len, dtype=torch.double)
+    full_response_mask[:, prompt_len:] = 1.0
+    advantages = torch.randn(batch, dtype=torch.double)
+    old_log_probs = torch.randn(batch, response_len, dtype=torch.double)
+
+    def objective(log_probs_input: torch.Tensor) -> torch.Tensor:
+        policy_loss, kl, entropy = trainer.compute_policy_losses(
+            log_probs_input,
+            ref_log_probs,
+            responses,
+            prompt_lengths,
+            response_lengths,
+            responses_mask,
+            full_response_mask,
+            advantages,
+            old_log_probs,
+        )
+        return policy_loss + trainer.kl * kl - trainer.entropy * entropy
+
+    assert gradcheck(objective, (log_probs,), eps=1e-6, atol=1e-4, rtol=1e-4)

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+import torch
+from torch.autograd import gradcheck
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(ROOT)
+
+from gpt import GPTConfig, GPT  # noqa: F401
+from train_sft import supervised_loss  # noqa: E402
+
+
+def test_supervised_loss_gradcheck():
+    torch.manual_seed(0)
+    batch = 2
+    seq = 3
+    vocab = 5
+
+    logits = torch.randn(batch, seq, vocab, dtype=torch.double, requires_grad=True)
+    targets = torch.randint(0, vocab, (batch, seq), dtype=torch.long)
+    mask = torch.ones(batch, seq, dtype=torch.double)
+
+    def objective(logits_input: torch.Tensor) -> torch.Tensor:
+        return supervised_loss(logits_input, targets, mask)
+
+    assert gradcheck(objective, (logits,), eps=1e-6, atol=1e-4, rtol=1e-4)

--- a/train_ppo.py
+++ b/train_ppo.py
@@ -1,6 +1,6 @@
-import argparse
 import os
 import random
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -24,12 +24,17 @@ class ScalarHead(nn.Module):
         return self.score(last).squeeze(-1)
 
 
-def pad_responses(responses: list[torch.Tensor], pad: int) -> tuple[torch.Tensor, torch.Tensor]:
+def pad_responses(
+    responses: list[torch.Tensor], pad: int
+) -> tuple[torch.Tensor, torch.Tensor]:
     if not responses:
-        return torch.zeros(0, 0, dtype=torch.long), torch.zeros(0, 0, dtype=torch.long)
+        return (
+            torch.zeros(0, 0, dtype=torch.long),
+            torch.zeros(0, 0, dtype=torch.float32),
+        )
     max_len = max(r.size(0) for r in responses)
     out = torch.full((len(responses), max_len), pad, dtype=torch.long)
-    mask = torch.zeros((len(responses), max_len), dtype=torch.long)
+    mask = torch.zeros((len(responses), max_len), dtype=torch.float32)
     for i, resp in enumerate(responses):
         length = resp.size(0)
         if length:
@@ -46,8 +51,8 @@ def build_full_sequences(
     full_lengths = [p.size(0) + r.size(0) for p, r in zip(prompts, responses)]
     max_full = max(full_lengths) if full_lengths else 0
     batch = torch.full((len(prompts), max_full), pad, dtype=torch.long)
-    mask = torch.zeros_like(batch)
-    response_mask = torch.zeros_like(batch)
+    mask = torch.zeros_like(batch, dtype=torch.float32)
+    response_mask = torch.zeros_like(batch, dtype=torch.float32)
     for i, (prompt, response) in enumerate(zip(prompts, responses)):
         p_len = prompt.size(0)
         r_len = response.size(0)
@@ -67,7 +72,7 @@ def gather_log_probs(
     response_lengths: torch.Tensor,
 ) -> torch.Tensor:
     batch, max_len = tokens.shape
-    out = torch.zeros(batch, max_len, device=log_probs.device)
+    out = log_probs.new_zeros(batch, max_len)
     for i in range(batch):
         r_len = int(response_lengths[i].item())
         start = int(prompt_lengths[i].item())
@@ -159,6 +164,40 @@ class PPOTrainer:
             "old_values": values,
         }
 
+    def compute_policy_losses(
+        self,
+        log_probs: torch.Tensor,
+        ref_log_probs: torch.Tensor,
+        responses: torch.Tensor,
+        prompt_lengths: torch.Tensor,
+        response_lengths: torch.Tensor,
+        responses_mask: torch.Tensor,
+        full_response_mask: torch.Tensor,
+        advantages: torch.Tensor,
+        old_log_probs: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        new_log_probs = gather_log_probs(
+            log_probs,
+            responses,
+            prompt_lengths,
+            response_lengths,
+        )
+
+        ratios = (new_log_probs - old_log_probs).exp()
+        policy_targets = advantages.unsqueeze(1) * responses_mask
+        unclipped = ratios * policy_targets
+        clipped = torch.clamp(ratios, 1.0 - self.clip, 1.0 + self.clip) * policy_targets
+        denom = responses_mask.sum().clamp(min=1.0)
+        policy_loss = -torch.sum(torch.minimum(unclipped, clipped)) / denom
+
+        probs = log_probs.exp()
+        kl_per_token = (probs * (log_probs - ref_log_probs)).sum(dim=-1)
+        kl = (kl_per_token * full_response_mask).sum() / full_response_mask.sum().clamp(min=1.0)
+
+        entropy_per_token = -(probs * log_probs).sum(dim=-1)
+        entropy = (entropy_per_token * full_response_mask).sum() / full_response_mask.sum().clamp(min=1.0)
+        return policy_loss, kl, entropy
+
     def train_step(self, batch: dict[str, torch.Tensor]) -> dict[str, float]:
         full = batch["full"]
         full_mask = batch["full_mask"]
@@ -172,32 +211,23 @@ class PPOTrainer:
 
         logits, _ = self.policy(full, attention_mask=full_mask)
         log_probs = F.log_softmax(logits, dim=-1)
-
-        new_log_probs = gather_log_probs(
-            log_probs,
-            responses,
-            prompt_lengths,
-            response_lengths,
-        )
-
-        ratios = (new_log_probs - old_log_probs).exp()
         advantages = batch["advantages"]
-        policy_targets = advantages.unsqueeze(1) * responses_mask
-        unclipped = ratios * policy_targets
-        clipped = torch.clamp(ratios, 1.0 - self.clip, 1.0 + self.clip) * policy_targets
-        denom = responses_mask.sum().clamp(min=1).float()
-        policy_loss = -torch.sum(torch.minimum(unclipped, clipped)) / denom
 
         with torch.no_grad():
             ref_logits, _ = self.reference(full, attention_mask=full_mask)
             ref_log_probs = F.log_softmax(ref_logits, dim=-1)
 
-        probs = log_probs.exp()
-        kl_per_token = (probs * (log_probs - ref_log_probs)).sum(dim=-1)
-        kl = (kl_per_token * response_mask).sum() / response_mask.sum().clamp(min=1).float()
-
-        entropy_per_token = -(probs * log_probs).sum(dim=-1)
-        entropy = (entropy_per_token * response_mask).sum() / response_mask.sum().clamp(min=1).float()
+        policy_loss, kl, entropy = self.compute_policy_losses(
+            log_probs,
+            ref_log_probs,
+            responses,
+            prompt_lengths,
+            response_lengths,
+            responses_mask,
+            response_mask,
+            advantages,
+            old_log_probs,
+        )
 
         rewards = batch["rewards"]
         values = self.value(full, full_mask)
@@ -257,30 +287,50 @@ def train_reward_model(
             opt.step()
 
 
-def run_rlhf(args: argparse.Namespace):
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    config = GPTConfig(dropout=args.dropout)
+def train_ppo(
+    preference_path: str,
+    *,
+    sft_path: Optional[str] = None,
+    out_dir: str = "ppo_weights",
+    dropout: float = 0.0,
+    rm_batch: int = 4,
+    rm_epochs: int = 1,
+    rm_lr: float = 1e-5,
+    ppo_batch: int = 4,
+    ppo_epochs: int = 1,
+    ppo_steps: int = 4,
+    max_new: int = 64,
+    ppo_lr: float = 1e-5,
+    clip: float = 0.2,
+    kl_coef: float = 0.1,
+    entropy_coef: float = 0.01,
+    device: Optional[torch.device] = None,
+) -> None:
+    if device is None:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    config = GPTConfig(dropout=dropout)
 
     policy = GPT(config).to(device)
     reference = GPT(config).to(device)
     value_model = ScalarHead(config).to(device)
     reward_model = ScalarHead(config).to(device)
 
-    if args.sft:
-        state = torch.load(args.sft, map_location="cpu")
+    if sft_path:
+        state = torch.load(sft_path, map_location="cpu")
         policy.load_state_dict(state, strict=False)
         reference.load_state_dict(state, strict=False)
         value_model.body.load_state_dict(state, strict=False)
         reward_model.body.load_state_dict(state, strict=False)
     reference.load_state_dict(policy.state_dict())
 
-    pref_data = PreferenceDataset(args.preference, block_size=config.block_size)
+    pref_data = PreferenceDataset(preference_path, block_size=config.block_size)
     train_reward_model(
         reward_model,
         pref_data,
-        batch_size=args.rm_batch,
-        epochs=args.rm_epochs,
-        lr=args.rm_lr,
+        batch_size=rm_batch,
+        epochs=rm_epochs,
+        lr=rm_lr,
         device=device,
     )
 
@@ -291,27 +341,27 @@ def run_rlhf(args: argparse.Namespace):
         value_model,
         reward_model,
         pad_token=bundle.pad,
-        clip=args.clip,
-        kl=args.kl,
-        entropy=args.entropy,
-        lr=args.ppo_lr,
+        clip=clip,
+        kl=kl_coef,
+        entropy=entropy_coef,
+        lr=ppo_lr,
     )
 
     prompts = [sample["prompt"] for sample in pref_data.samples]
     random.shuffle(prompts)
     batches = [
-        prompts[i : i + args.ppo_batch]
-        for i in range(0, len(prompts), args.ppo_batch)
+        prompts[i : i + ppo_batch]
+        for i in range(0, len(prompts), ppo_batch)
     ]
 
     policy.train()
-    for epoch in range(args.ppo_epochs):
+    for epoch in range(ppo_epochs):
         for batch_prompts in batches:
             if not batch_prompts:
                 continue
             pad_len = max(p.size(0) for p in batch_prompts)
             prompt_tensor = torch.full((len(batch_prompts), pad_len), bundle.pad, dtype=torch.long)
-            prompt_mask = torch.zeros_like(prompt_tensor)
+            prompt_mask = torch.zeros_like(prompt_tensor, dtype=torch.float32)
             for i, prompt in enumerate(batch_prompts):
                 length = prompt.size(0)
                 prompt_tensor[i, :length] = prompt
@@ -319,7 +369,7 @@ def run_rlhf(args: argparse.Namespace):
             prompt_tensor = prompt_tensor.to(device)
             prompt_mask = prompt_mask.to(device)
 
-            sampled = trainer.sample(prompt_tensor, prompt_mask, args.max_new)
+            sampled = trainer.sample(prompt_tensor, prompt_mask, max_new)
 
             full = sampled["full"]
             mask = sampled["full_mask"]
@@ -329,36 +379,51 @@ def run_rlhf(args: argparse.Namespace):
             sampled["advantages"] = advantages.detach()
             sampled["rewards"] = rewards.detach()
 
-            for _ in range(args.ppo_steps):
+            for _ in range(ppo_steps):
                 metrics = trainer.train_step(sampled)
 
-        if args.out:
-            os.makedirs(args.out, exist_ok=True)
-            path = os.path.join(args.out, f"ppo_epoch_{epoch+1}.pt")
+        if out_dir:
+            os.makedirs(out_dir, exist_ok=True)
+            path = os.path.join(out_dir, f"ppo_epoch_{epoch+1}.pt")
             torch.save(policy.state_dict(), path)
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("preference", type=str)
-    parser.add_argument("--sft", type=str, default=None)
-    parser.add_argument("--out", type=str, default="ppo_weights")
-    parser.add_argument("--dropout", type=float, default=0.0)
-    parser.add_argument("--rm_batch", type=int, default=4)
-    parser.add_argument("--rm_epochs", type=int, default=1)
-    parser.add_argument("--rm_lr", type=float, default=1e-5)
-    parser.add_argument("--ppo_batch", type=int, default=4)
-    parser.add_argument("--ppo_epochs", type=int, default=1)
-    parser.add_argument("--ppo_steps", type=int, default=4)
-    parser.add_argument("--max_new", type=int, default=64)
-    parser.add_argument("--ppo_lr", type=float, default=1e-5)
-    parser.add_argument("--clip", type=float, default=0.2)
-    parser.add_argument("--kl", type=float, default=0.1)
-    parser.add_argument("--entropy", type=float, default=0.01)
-    args = parser.parse_args()
-
-    run_rlhf(args)
-
-
 if __name__ == "__main__":
-    main()
+    PREFERENCE_PATH = "data/preferences_train.jsonl"
+    SFT_PATH = None
+    OUT_DIR = "ppo_weights"
+    DROPOUT = 0.0
+    RM_BATCH = 4
+    RM_EPOCHS = 1
+    RM_LR = 1e-5
+    PPO_BATCH = 4
+    PPO_EPOCHS = 1
+    PPO_STEPS = 4
+    MAX_NEW = 64
+    PPO_LR = 1e-5
+    CLIP = 0.2
+    KL_COEF = 0.1
+    ENTROPY_COEF = 0.01
+
+    if not os.path.exists(PREFERENCE_PATH):
+        raise FileNotFoundError(
+            f"Preference data not found at {PREFERENCE_PATH}. Update the path before running."
+        )
+
+    train_ppo(
+        PREFERENCE_PATH,
+        sft_path=SFT_PATH,
+        out_dir=OUT_DIR,
+        dropout=DROPOUT,
+        rm_batch=RM_BATCH,
+        rm_epochs=RM_EPOCHS,
+        rm_lr=RM_LR,
+        ppo_batch=PPO_BATCH,
+        ppo_epochs=PPO_EPOCHS,
+        ppo_steps=PPO_STEPS,
+        max_new=MAX_NEW,
+        ppo_lr=PPO_LR,
+        clip=CLIP,
+        kl_coef=KL_COEF,
+        entropy_coef=ENTROPY_COEF,
+    )


### PR DESCRIPTION
## Summary
- refactor `train_sft.py` and `train_ppo.py` into single-GPU friendly entrypoints with module-level configuration constants instead of argparse
- add reusable loss helpers, ensure mask dtypes are consistent, and expose PPO policy-loss computation for analysis
- document RTX 4090 capacity planning guidance and new usage patterns in the README
- add gradient-checking unit tests for both the SFT objective and PPO policy update

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce306bc2348322833f4a3434404a4f