### PR TITLE
Update PPO defaults for SFT init and larger batches

### DIFF
--- a/train_ppo.py
+++ b/train_ppo.py
@@ -353,10 +353,10 @@ def train_ppo(
 def main() -> None:
     preference_path = "data/hh_rlhf_preferences_train.jsonl"
     reward_path = "weights/reward_model.pt"
-    policy_init = None
+    policy_init = "weights/sft.pt"
     out_path = "weights/ppo_policy.pt"
-    batch_size = 4
-    epochs = 1
+    batch_size = 8
+    epochs = 4
     max_new_tokens = 64
     lr = 1e-5
     clip = 0.2


### PR DESCRIPTION
## Summary
- default PPO training now initializes policy, reference, and value networks from the supervised fine-tuning checkpoint
- increased default PPO batch size and epochs to support more stable updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d08f0e56708322b1386ca0cfdb3560