### PR TITLE
Add inference script for qualitative text generation

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -1,0 +1,78 @@
+"""Simple inference script for qualitative inspection of GPT checkpoints."""
+
+from __future__ import annotations
+
+import torch
+
+from data import TokenizerBundle, build_tokenizer
+from gpt import GPT, GPTConfig
+
+
+def load_model(weights_path: str, device: torch.device) -> GPT:
+    """Load a ``GPT`` instance from ``weights_path`` and move it to ``device``."""
+
+    config = GPTConfig()
+    model = GPT(config)
+    state = torch.load(weights_path, map_location=device)
+    model.load_state_dict(state, strict=False)
+    model.to(device)
+    model.eval()
+    return model
+
+
+def prepare_prompt(bundle: TokenizerBundle, prompt: str, device: torch.device) -> torch.Tensor:
+    """Convert ``prompt`` into a tensor including the BOS token."""
+
+    tokens = [bundle.bos] + bundle.encode(prompt)
+    tensor = torch.tensor(tokens, dtype=torch.long, device=device).unsqueeze(0)
+    return tensor
+
+
+def generate_text(
+    model: GPT,
+    bundle: TokenizerBundle,
+    prompt: str,
+    *,
+    max_new_tokens: int = 128,
+    temperature: float = 0.8,
+) -> str:
+    """Generate text from ``model`` given ``prompt`` and decode it to a string."""
+
+    if temperature <= 0:
+        raise ValueError("temperature must be positive")
+
+    device = next(model.parameters()).device
+    input_tokens = prepare_prompt(bundle, prompt, device)
+    sequence = model.generate(
+        input_tokens,
+        max_new_tokens=max_new_tokens,
+        temperature=temperature,
+        eos_token=bundle.eos,
+    )
+    generated_tokens = sequence[0].tolist()
+
+    # Drop the leading BOS and stop at EOS if present.
+    if bundle.bos in generated_tokens:
+        generated_tokens = generated_tokens[1:]
+    if bundle.eos in generated_tokens:
+        eos_index = generated_tokens.index(bundle.eos)
+        generated_tokens = generated_tokens[:eos_index]
+
+    return bundle.encoder.decode(generated_tokens)
+
+
+def main() -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    weights_path = "weights/sft.pt"
+    prompt = "Human: Explain the importance of reinforcement learning from human feedback.\nAssistant:"
+
+    bundle = build_tokenizer()
+    model = load_model(weights_path, device)
+    completion = generate_text(model, bundle, prompt, max_new_tokens=120, temperature=0.8)
+
+    print("Prompt:\n" + prompt)
+    print("\nModel completion:\n" + completion)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add an inference helper that loads GPT checkpoints and decodes completions with the repo tokenizer
- provide a main entry point with a hard-coded evaluation prompt for easy manual runs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0cc3cb32883228bddc6ca2c11473e