### PR TITLE
Mask prompt tokens from supervised loss

### DIFF
--- a/data.py
+++ b/data.py
@@ -46,10 +46,12 @@ def load_jsonl(path: str | Path) -> Iterable[dict]:
                 yield json.loads(line)
 
 
-def _split_into_sequences(tokens: list[int], block_size: int) -> Iterable[list[int]]:
+def _split_into_sequences(
+    tokens: list[int], block_size: int
+) -> Iterable[tuple[int, list[int]]]:
     step = block_size + 1
     for start in range(0, max(0, len(tokens) - 1), block_size):
-        yield tokens[start : start + step]
+        yield start, tokens[start : start + step]
 
 
 class SupervisedDataset(Dataset):
@@ -64,24 +66,31 @@ class SupervisedDataset(Dataset):
     def __init__(self, path: str | Path, block_size: int) -> None:
         self.bundle = build_tokenizer()
         self.block_size = block_size
-        self.data: list[tuple[torch.Tensor, torch.Tensor]] = []
+        self.data: list[tuple[torch.Tensor, torch.Tensor, int]] = []
 
         for row in load_jsonl(path):
             prompt = row.get("prompt", "")
             answer = row.get("chosen", row.get("response", ""))
-            text = prompt + answer
-            tokens = [self.bundle.bos] + self.bundle.encode(text) + [self.bundle.eos]
-            for chunk in _split_into_sequences(tokens, block_size):
+            prompt_tokens = [self.bundle.bos] + self.bundle.encode(prompt)
+            prompt_length = len(prompt_tokens)
+            tokens = prompt_tokens + self.bundle.encode(answer) + [self.bundle.eos]
+            for start, chunk in _split_into_sequences(tokens, block_size):
                 if len(chunk) < 2:
                     continue
                 x_tokens = torch.tensor(chunk[:-1], dtype=torch.long)
                 y_tokens = torch.tensor(chunk[1:], dtype=torch.long)
-                self.data.append((x_tokens, y_tokens))
+                first_target_idx = start + 1
+                chunk_end = start + len(chunk)
+                prompt_in_chunk = 0
+                if first_target_idx < prompt_length:
+                    prompt_in_chunk = min(prompt_length, chunk_end) - first_target_idx
+                    prompt_in_chunk = max(prompt_in_chunk, 0)
+                self.data.append((x_tokens, y_tokens, int(prompt_in_chunk)))
 
     def __len__(self) -> int:
         return len(self.data)
 
-    def __getitem__(self, index: int) -> tuple[torch.Tensor, torch.Tensor]:
+    def __getitem__(self, index: int) -> tuple[torch.Tensor, torch.Tensor, int]:
         return self.data[index]
 
 
@@ -132,13 +141,31 @@ def _pad_sequences(seqs: list[torch.Tensor], pad_value: int) -> tuple[torch.Tens
     return batch, mask
 
 
-def collate_supervised(batch: list[tuple[torch.Tensor, torch.Tensor]], pad_token: int) -> dict[str, torch.Tensor]:
-    inputs, targets = zip(*batch)
-    x, mask = _pad_sequences(list(inputs), pad_token)
+def collate_supervised(
+    batch: list[tuple[torch.Tensor, torch.Tensor, int]], pad_token: int
+) -> dict[str, torch.Tensor]:
+    inputs, targets, prompt_lengths = zip(*batch)
+    x, attention_mask = _pad_sequences(list(inputs), pad_token)
     y, _ = _pad_sequences(list(targets), -1)
     y = y.long()
-    y[mask == 0] = -1
-    return {"input_ids": x, "target_ids": y, "attention_mask": mask}
+    y[attention_mask == 0] = -1
+
+    label_masks: list[torch.Tensor] = []
+    for target, prompt_len in zip(targets, prompt_lengths):
+        seq_len = target.size(0)
+        prompt_len = min(prompt_len, seq_len)
+        label_mask = torch.zeros(seq_len, dtype=torch.long)
+        if prompt_len < seq_len:
+            label_mask[prompt_len:] = 1
+        label_masks.append(label_mask)
+    label_mask, _ = _pad_sequences(label_masks, 0)
+
+    return {
+        "input_ids": x,
+        "target_ids": y,
+        "attention_mask": attention_mask,
+        "label_mask": label_mask,
+    }
 
 
 def collate_preferences(batch: list[dict[str, torch.Tensor]], pad_token: int) -> dict[str, torch.Tensor]:

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -25,3 +25,25 @@ def test_supervised_loss_gradcheck():
         return supervised_loss(logits_input, targets, mask)
 
     assert gradcheck(objective, (logits,), eps=1e-6, atol=1e-4, rtol=1e-4)
+
+
+def test_supervised_loss_ignores_prompt_tokens():
+    torch.manual_seed(0)
+    batch = 1
+    seq = 4
+    vocab = 3
+
+    logits = torch.zeros(batch, seq, vocab, dtype=torch.double, requires_grad=True)
+    targets = torch.tensor([[0, 1, 2, 0]], dtype=torch.long)
+    label_mask = torch.tensor([[0.0, 0.0, 1.0, 1.0]], dtype=torch.double)
+
+    base_loss = supervised_loss(logits, targets, label_mask)
+
+    # Changing prompt logits should not affect the loss as they are masked out.
+    modified_logits = logits.clone().detach()
+    modified_logits[0, 0, :] = torch.tensor([10.0, -10.0, 0.0], dtype=torch.double)
+    modified_logits[0, 1, :] = torch.tensor([-5.0, 5.0, 0.0], dtype=torch.double)
+    modified_logits.requires_grad_(True)
+    masked_loss = supervised_loss(modified_logits, targets, label_mask)
+
+    assert torch.allclose(base_loss, masked_loss)

--- a/train_sft.py
+++ b/train_sft.py
@@ -8,10 +8,12 @@ from data import SupervisedDataset, collate_supervised
 from gpt import GPT, GPTConfig
 
 
-def supervised_loss(logits: torch.Tensor, targets: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
-    """Cross entropy between ``logits`` and ``targets`` masked on padding.
+def supervised_loss(
+    logits: torch.Tensor, targets: torch.Tensor, label_mask: torch.Tensor
+) -> torch.Tensor:
+    """Cross entropy between ``logits`` and ``targets`` masked on labels.
 
-    The mask marks the valid positions inside each sequence.  ``targets`` is the
+    The mask marks the valid label positions inside each sequence.  ``targets`` is the
     input sequence shifted by one position which makes the language modelling
     objective explicit: the model learns to predict the next token ``y`` from the
     observed prefix ``x``.
@@ -20,7 +22,7 @@ def supervised_loss(logits: torch.Tensor, targets: torch.Tensor, mask: torch.Ten
     vocab = logits.size(-1)
     flat_logits = logits.view(-1, vocab)
     flat_targets = targets.view(-1)
-    flat_mask = mask.view(-1).to(logits.dtype)
+    flat_mask = label_mask.view(-1).to(logits.dtype)
 
     per_token = torch.nn.functional.cross_entropy(
         flat_logits,
@@ -81,14 +83,15 @@ def train_sft(
         for batch in loader:
             tokens = batch["input_ids"].to(device)
             targets = batch["target_ids"].to(device)
-            mask = batch["attention_mask"].to(device)
+            attention_mask = batch["attention_mask"].to(device)
+            label_mask = batch["label_mask"].to(device)
 
-            logits, _ = model(tokens, attention_mask=mask)
-            loss = supervised_loss(logits, targets, mask)
+            logits, _ = model(tokens, attention_mask=attention_mask)
+            loss = supervised_loss(logits, targets, label_mask)
 
             with torch.no_grad():
                 predictions = logits.argmax(dim=-1)
-                valid = (targets != -1) & mask.bool()
+                valid = (targets != -1) & label_mask.bool()
                 correct_tokens += (predictions.eq(targets) & valid).sum().item()
                 total_tokens += valid.sum().item()
                 running_loss += loss.item()


### PR DESCRIPTION
## Summary
- track prompt lengths for each supervised chunk and emit a label mask during collation
- update the supervised loss and SFT training loop to ignore prompt tokens when computing loss and accuracy
- add a regression test ensuring prompt tokens do not influence the supervised loss

## Testing
- pytest tests/test_sft.py

------
https://chatgpt.com/codex/tasks/task_e_68d0d47a25048322848d453987953f84