### PR TITLE
Simplify checkpoint loading and add legacy conversion tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ can either import and call it directly or edit the constants at the bottom of
 Both training scripts now assume single-GPU execution. Gradient accumulation is
 available through the shared `grad_accumulation_steps` argument.
 
+### Preparing legacy checkpoints
+
+If you are starting from a checkpoint that was saved with a different module
+layout (for example, raw GPT-2 weights from Hugging Face), run it through
+`scripts/format_checkpoint.py` once. The script transposes the older projection
+matrices and optionally adds a prefix before writing a clean `.pt` file that the
+trainers can load directly.
+
 ## Testing
 
 Unit tests (including gradient checks for both the SFT loss and the PPO policy objective) can be run with:

--- a/gpt.py
+++ b/gpt.py
@@ -1,7 +1,6 @@
 import math
-from collections import OrderedDict
 from dataclasses import dataclass
-from typing import MutableMapping, Optional
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -181,56 +180,3 @@ class GPT(nn.Module):
             if eos_token is not None and torch.any(next_token == eos_token):
                 break
         return sequence
-
-
-_TRANSPOSE_SUFFIXES = (
-    "attn.c_attn.weight",
-    "attn.c_proj.weight",
-    "mlp.c_fc.weight",
-    "mlp.c_proj.weight",
-)
-
-
-def _should_transpose(key: str, value: torch.Tensor, state_dict: MutableMapping[str, torch.Tensor]) -> bool:
-    if value.ndim != 2 or not any(key.endswith(suffix) for suffix in _TRANSPOSE_SUFFIXES):
-        return False
-
-    bias_key = key[:-6] + "bias"
-    bias = state_dict.get(bias_key)
-    if bias is None or bias.ndim != 1:
-        return False
-
-    expected_out = bias.shape[0]
-    if value.shape[0] == expected_out:
-        return False
-    if value.shape[1] == expected_out:
-        return True
-    return False
-
-
-def maybe_transpose_gpt_state_dict(
-    state_dict: MutableMapping[str, torch.Tensor],
-) -> MutableMapping[str, torch.Tensor]:
-    """Transpose legacy GPT-2 weight matrices to match the current module layout."""
-
-    keys_to_transpose = {
-        key
-        for key, value in state_dict.items()
-        if _should_transpose(key, value, state_dict)
-    }
-
-    if not keys_to_transpose:
-        return state_dict
-
-    new_state: MutableMapping[str, torch.Tensor]
-    if isinstance(state_dict, OrderedDict):
-        new_state = OrderedDict()
-    else:
-        new_state = {}
-
-    for key, value in state_dict.items():
-        if key in keys_to_transpose:
-            new_state[key] = value.transpose(0, 1)
-        else:
-            new_state[key] = value
-    return new_state

--- a/scripts/format_checkpoint.py
+++ b/scripts/format_checkpoint.py
@@ -1,0 +1,97 @@
+"""Utility helpers for converting legacy GPT-2 checkpoints.
+
+Run this script once on weights that were saved with an older layout or with
+transpose requirements. The training code now assumes checkpoints are already
+in the "nanogpt-style" layout, so we keep the conversion logic here instead of
+sprinkling it across the trainers.
+"""
+
+import argparse
+from collections import OrderedDict
+from typing import MutableMapping
+
+import torch
+
+_TRANSPOSE_SUFFIXES = (
+    "attn.c_attn.weight",
+    "attn.c_proj.weight",
+    "mlp.c_fc.weight",
+    "mlp.c_proj.weight",
+)
+
+
+def _should_transpose(
+    key: str, value: torch.Tensor, state_dict: MutableMapping[str, torch.Tensor]
+) -> bool:
+    if value.ndim != 2 or not any(key.endswith(suffix) for suffix in _TRANSPOSE_SUFFIXES):
+        return False
+
+    bias_key = key[:-6] + "bias"
+    bias = state_dict.get(bias_key)
+    if bias is None or bias.ndim != 1:
+        return False
+
+    expected_out = bias.shape[0]
+    if value.shape[0] == expected_out:
+        return False
+    if value.shape[1] == expected_out:
+        return True
+    return False
+
+
+def transpose_legacy_state(
+    state_dict: MutableMapping[str, torch.Tensor]
+) -> MutableMapping[str, torch.Tensor]:
+    keys_to_transpose = {
+        key
+        for key, value in state_dict.items()
+        if _should_transpose(key, value, state_dict)
+    }
+
+    if not keys_to_transpose:
+        return state_dict
+
+    if isinstance(state_dict, OrderedDict):
+        converted: MutableMapping[str, torch.Tensor] = OrderedDict()
+    else:
+        converted = {}
+
+    for key, value in state_dict.items():
+        if key in keys_to_transpose:
+            converted[key] = value.transpose(0, 1)
+        else:
+            converted[key] = value
+    return converted
+
+
+def add_prefix(state_dict: MutableMapping[str, torch.Tensor], prefix: str) -> None:
+    if not prefix:
+        return
+    for key in list(state_dict.keys()):
+        state_dict[f"{prefix}{key}"] = state_dict.pop(key)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=str, help="Path to the legacy checkpoint")
+    parser.add_argument("output", type=str, help="Where to write the converted checkpoint")
+    parser.add_argument(
+        "--prefix",
+        type=str,
+        default="",
+        help=(
+            "Optional prefix to add to every key. Useful for preparing policy weights "
+            "for modules such as ScalarHead.body."
+        ),
+    )
+    args = parser.parse_args()
+
+    state = torch.load(args.input, map_location="cpu")
+    state = transpose_legacy_state(state)
+    if args.prefix:
+        add_prefix(state, args.prefix)
+    torch.save(state, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/train_ppo.py
+++ b/train_ppo.py
@@ -8,23 +8,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from data import PreferenceDataset
-from gpt import GPT, GPTConfig, maybe_transpose_gpt_state_dict
+from gpt import GPT, GPTConfig
 from train_rm import ScalarHead
-
-
-
-def _resolve_policy_state(init_checkpoint: Optional[str]) -> tuple[GPTConfig, dict | None]:
-    config = GPTConfig()
-    state = None
-    if init_checkpoint:
-        if not os.path.exists(init_checkpoint):
-            raise FileNotFoundError(
-                f"Initial policy checkpoint {init_checkpoint} does not exist; provide a Torch state dict"
-            )
-        state = torch.load(init_checkpoint, map_location="cpu")
-        state = maybe_transpose_gpt_state_dict(state)
-    return config, state
-
 
 class ValueHead(nn.Module):
     """Lightweight value projection sharing the policy transformer."""
@@ -304,7 +289,7 @@ def train_ppo(
             f"Reward model weights not found at {reward_path}. Train the reward model first."
         )
 
-    config, policy_state = _resolve_policy_state(policy_init)
+    config = GPTConfig()
     dataset = PreferenceDataset(preference_path, block_size=config.block_size)
     bundle = dataset.bundle
     if bundle.encoder.n_vocab != config.vocab_size:
@@ -316,12 +301,16 @@ def train_ppo(
     reference = GPT(config)
     reward_model = ScalarHead(config)
 
-    if policy_state is not None:
+    if policy_init is not None:
+        if not os.path.exists(policy_init):
+            raise FileNotFoundError(
+                f"Initial policy checkpoint {policy_init} does not exist; provide a Torch state dict"
+            )
+        policy_state = torch.load(policy_init, map_location="cpu")
         policy.load_state_dict(policy_state, strict=False)
 
     reference.load_state_dict(policy.state_dict())
     reward_state = torch.load(reward_path, map_location="cpu")
-    reward_state = maybe_transpose_gpt_state_dict(reward_state)
     reward_model.load_state_dict(reward_state, strict=False)
 
     value_head = ValueHead(config.n_embd)


### PR DESCRIPTION
## Summary
- remove the on-the-fly GPT weight transposition logic from the model and training scripts
- simplify the SFT, RM, and PPO trainers to load checkpoints directly when provided
- add a standalone `scripts/format_checkpoint.py` helper for preparing legacy GPT-2 weights and document its usage in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1d5ea388883228817944b2d8e8088