### PR TITLE
fix LaTeX rendering in markdown notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ masks and last-token indices.
 Artifact: dataset shape/dtype test passes.
 
 **3.3 Bradley–Terry loss.**
-`L = -log σ(r_c - r_r)`. Derive ∂L/∂r_c and ∂L/∂r_r in `notes/03-rm.md`, including the
+$L = -\log \sigma(r_c - r_r)$. Derive $\partial L/\partial r_c$ and $\partial L/\partial r_r$ in `notes/03-rm.md`, including the
 softplus form for numerical stability. Gradient-check at fp64.
 Artifact: test_grad_rm.py passes.
 

--- a/notes/03-rm.md
+++ b/notes/03-rm.md
@@ -109,7 +109,7 @@ This equivalent form is what you implement because:
   underflows to 0, and $\log(1 + 0)$ is stable and near 0. Good.
 - For large negative $\Delta$ (the RM is confidently wrong): the naive
   $\log(1 + e^{-\Delta})$ sends $e^{-\Delta}$ to $+\infty$, which overflows in bf16.
-  But `F.softplus(-\Delta)` is implemented with branching that computes
+  But `F.softplus` applied to $-\Delta$ is implemented with branching that computes
   $\max(-\Delta, 0) + \log(1 + e^{-|\Delta|})$, which is stable in both directions.
 
 Always use `F.softplus(r_r - r_c)` or the equivalent trick — never `-log(sigmoid(...))`.

--- a/notes/04-ppo-policy.md
+++ b/notes/04-ppo-policy.md
@@ -84,14 +84,14 @@ $\varepsilon = 0.2$ is the clip range. Per token:
 
 There are four cases based on the sign of $A_t$ and whether $\rho$ is inside the clip:
 
-| $A_t$ sign | $\rho$ position            | surr$_1$ vs surr$_2$        | min picks | Gradient w.r.t. $\log \pi$ |
+| $A_t$ sign | $\rho$ position            | $\text{surr}_1$ vs $\text{surr}_2$        | min picks | Gradient w.r.t. $\log \pi$ |
 |------------|----------------------------|-----------------------------|-----------|----------------------------|
-| $A > 0$    | $\rho \in [1-\varepsilon, 1+\varepsilon]$ | equal                | surr$_1$  | $-A \cdot \rho$            |
-| $A > 0$    | $\rho > 1 + \varepsilon$   | surr$_1$ bigger (= $\rho A$) | surr$_2$  | **zero** (clipped)         |
-| $A > 0$    | $\rho < 1 - \varepsilon$   | surr$_1$ smaller            | surr$_1$  | $-A \cdot \rho$ (not clipped)|
-| $A < 0$    | $\rho \in [1-\varepsilon, 1+\varepsilon]$ | equal                | surr$_1$  | $-A \cdot \rho$            |
-| $A < 0$    | $\rho < 1 - \varepsilon$   | surr$_1$ less negative      | surr$_2$  | **zero** (clipped)         |
-| $A < 0$    | $\rho > 1 + \varepsilon$   | surr$_1$ more negative      | surr$_1$  | $-A \cdot \rho$ (not clipped)|
+| $A > 0$    | $\rho \in [1-\varepsilon, 1+\varepsilon]$ | equal                | $\text{surr}_1$  | $-A \cdot \rho$            |
+| $A > 0$    | $\rho > 1 + \varepsilon$   | $\text{surr}_1$ bigger (= $\rho A$) | $\text{surr}_2$  | **zero** (clipped)         |
+| $A > 0$    | $\rho < 1 - \varepsilon$   | $\text{surr}_1$ smaller            | $\text{surr}_1$  | $-A \cdot \rho$ (not clipped)|
+| $A < 0$    | $\rho \in [1-\varepsilon, 1+\varepsilon]$ | equal                | $\text{surr}_1$  | $-A \cdot \rho$            |
+| $A < 0$    | $\rho < 1 - \varepsilon$   | $\text{surr}_1$ less negative      | $\text{surr}_2$  | **zero** (clipped)         |
+| $A < 0$    | $\rho > 1 + \varepsilon$   | $\text{surr}_1$ more negative      | $\text{surr}_1$  | $-A \cdot \rho$ (not clipped)|
 
 The pattern: **clipping only fires when it would drag the objective back** (i.e.
 the policy is already moving in a good direction and has gone "too far"). It *does
@@ -119,7 +119,7 @@ zero.
 
 You verify this with an **edge test** in Problem 4.5: set all ratios to a large value
 ($\rho = 5$, say) and $A > 0$. Every token should be in the "$A > 0$, $\rho > 1+\varepsilon$,
-clip picks surr$_2$" regime. Autograd must report exactly zero gradient on those
+clip picks $\text{surr}_2$" regime. Autograd must report exactly zero gradient on those
 tokens. If it reports nonzero, your implementation is using `max` instead of `min`
 or has a sign error.
 


### PR DESCRIPTION
- 04-ppo-policy.md: surr$_1$ / surr$_2$ had "surr" outside math mode; changed
  to $\text{surr}_1$ / $\text{surr}_2$ throughout the table and prose
- 03-rm.md: `F.softplus(-\Delta)` mixed code backtick with LaTeX \Delta, which
  renders literally; rephrased to keep F.softplus as code and -Delta as math
- README.md: `L = -log σ(r_c - r_r)` was a math formula in code backticks;
  converted to proper LaTeX, and bare Unicode ∂ derivatives to $\partial$ form

https://claude.ai/code/session_01H9HvgLLr2GARnrWPTET6V3