### PR TITLE
Simplify notes for undergraduate-level clarity

### DIFF
--- a/notes/00-data.md
+++ b/notes/00-data.md
@@ -2,21 +2,24 @@
 
 ## Purpose
 
-Read this *before* implementing `data_hh.py` (Problem 0.2). It tells you what the dataset
-looks like, what three derived datasets you need to produce, and what the chat template
-is. You are not deriving anything on paper here — this is a data contract.
+Read this *before* you write `data_hh.py` (Problem 0.2). It's a data contract, not a
+derivation. You're not doing math here — you're figuring out what the dataset looks like,
+what you need to produce from it, and how to format everything consistently.
 
 ---
 
 ## 1. What is HH-RLHF?
 
-`Anthropic/hh-rlhf` is a human-preference dataset released with Bai et al. 2022
-("Training a Helpful and Harmless Assistant with Reinforcement Learning from Human
-Feedback"). Each example is a pair of multi-turn dialogues that share the same prompt
-prefix but end with two different candidate assistant responses. Humans chose which one
-was better; `chosen` is the preferred one, `rejected` is the other.
+HH-RLHF stands for "Helpful and Harmless, with RLHF". Anthropic released it alongside
+Bai et al. 2022 ("Training a Helpful and Harmless Assistant with Reinforcement Learning
+from Human Feedback").
 
-Raw schema (per row):
+Each row in the dataset is a pair of conversations. Both conversations start the same
+way (same user questions, same earlier assistant replies), but they end differently —
+one ending was picked by a human labeler as "better", and the other was not. The picked
+one is called **chosen** and the other is called **rejected**.
+
+Here is what a raw row looks like:
 
 ```json
 {
@@ -25,27 +28,29 @@ Raw schema (per row):
 }
 ```
 
-Both strings are the full dialogue including all prior turns. The difference between
-`chosen` and `rejected` is usually just the final assistant turn, but *in principle* can
-diverge earlier. Treat them as two full trajectories, not "prompt + two endings".
+Both strings are the full dialogue, including all earlier turns. Usually only the final
+assistant turn differs between chosen and rejected, but not always — in principle the
+conversations could diverge earlier. Treat them as two full trajectories, not as
+"one prompt with two possible endings".
 
-The dataset has two major subsets — helpful-base and harmless-base. You can use the full
-`Anthropic/hh-rlhf` mix without splitting them for this course.
+The dataset is split into two subsets, `helpful-base` and `harmless-base`. For this
+course just use the whole `Anthropic/hh-rlhf` mix — don't bother separating them.
 
-Key statistics to verify yourself in Problem 0.2 (fill in the actual numbers):
+When you run Problem 0.2, you'll fill in the following statistics for yourself:
 
-- Number of train/test rows
-- Distribution of turn counts (most are 1–4 human turns)
-- Token-length percentiles (p50, p95, p99) of `chosen` and `rejected` under the GPT-2
-  BPE tokenizer
-- 3 random samples printed verbatim
+- Number of rows in train and test.
+- How many turns the typical conversation has (most are 1–4 human turns).
+- Token length percentiles (p50, p95, p99) for `chosen` and `rejected`, measured with
+  the GPT-2 BPE tokenizer.
+- Three random samples printed verbatim, just so you've eyeballed real data.
 
 ---
 
 ## 2. Chat template
 
-GPT-2's pretraining corpus is raw web text. It has no notion of "user" vs "assistant".
-To teach it turn structure, we wrap each turn in role tags:
+GPT-2 was pretrained on raw web text. It has no concept of "this bit is the user
+talking, this bit is the assistant talking". We have to teach it that by wrapping every
+turn in special role tags. Here is the template we use:
 
 ```
 <|im_start|>user
@@ -54,27 +59,28 @@ To teach it turn structure, we wrap each turn in role tags:
 <turn text><|im_end|>
 ```
 
-This is the ChatML template originally popularized by OpenAI's chat models. We enforce it
-end-to-end — SFT examples, RM preference pairs, and PPO rollouts all use exactly this
-format.
+This format is called ChatML. OpenAI popularized it with their chat models. We'll use
+it everywhere — SFT examples, RM preference pairs, PPO rollouts — so the model sees the
+same structure during every phase of training.
 
 ### Special tokens
 
-`<|im_start|>` and `<|im_end|>` are **not** in the base GPT-2 BPE vocabulary. You have
-two legitimate options:
+`<|im_start|>` and `<|im_end|>` are not real tokens in GPT-2's vocabulary. We have two
+reasonable options:
 
-1. **Reserve two unused BPE ids** and treat them as new special tokens.
-2. **Encode them as their literal UTF-8 bytes** and let BPE split them into several
-   subwords (`<`, `|`, `im`, `_start`, `|`, `>`, ...).
+1. Pick two unused slots in the vocab and treat them as new special tokens.
+2. Just type the literal text `<|im_start|>` and let the BPE tokenizer split it into a
+   handful of ordinary subword tokens (`<`, `|`, `im`, `_start`, `|`, `>`, and so on).
 
-The existing `train.jsonl` / `test.jsonl` in this repo use option (2). Stick with (2)
-for minimal churn. It's slightly wasteful (6–8 tokens per tag instead of 1) but does
-not require touching the embedding table.
+The `train.jsonl` / `test.jsonl` files already in this repo use option (2), so we'll
+stick with option (2) too. It wastes 6–8 tokens per tag instead of 1, but it means we
+don't have to resize the embedding table or do anything custom at tokenization time.
 
 ### Role labels
 
-We use `user` and `assistant`. HH uses `Human:` / `Assistant:` in the raw string. Your
-formatter's job is to convert from raw HH format to the ChatML template.
+We write the roles as `user` and `assistant`. The raw HH data uses `Human:` and
+`Assistant:` instead, so part of your formatter's job is to translate `Human:` → `user`
+and `Assistant:` → `assistant` while wrapping everything in the ChatML tags.
 
 ---
 
@@ -84,69 +90,91 @@ One source, three views. All three live in `data_hh.py`.
 
 ### 3.1 SFT dataset
 
-**Purpose:** teach the base model to produce text in the chat format and to imitate the
-distribution of `chosen` assistant responses.
+**Purpose.** Teach the base model (a) to produce text in our chat format, and (b) to
+imitate the `chosen` assistant responses.
 
-- One example = one full formatted dialogue (the `chosen` string, reformatted into
-  ChatML).
-- Returns `input_ids` (the whole dialogue tokenized) and a `loss_mask` of the same shape.
-- `loss_mask[t] = 1` iff token $t$ lies inside an **assistant turn's content** (the
-  tokens between `<|im_start|>assistant\n` and the following `<|im_end|>`, **including**
-  the `<|im_end|>`), else 0.
+Each example is one full formatted dialogue — the `chosen` string, rewritten into our
+ChatML template. The dataloader returns two tensors:
 
-This last point is the single most common SFT bug. See `02-sft.md` for why masking the
-prompt matters — this is critical to get right, as downstream RM and PPO depend on it.
+- `input_ids`: the whole dialogue tokenized into a 1D sequence.
+- `loss_mask`: a 0/1 sequence of the same length. `loss_mask[t] = 1` only if the token
+  at position `t` is inside an **assistant turn's content**. By "content" we mean the
+  text between the `<|im_start|>assistant\n` header and the following `<|im_end|>`,
+  and we include the `<|im_end|>` itself.
 
-### 3.2 Preference dataset (for RM)
+This mask is the thing that breaks most often in an SFT implementation. We go deeper
+on it in `02-sft.md`. Downstream, RM and PPO both assume this mask is correct, so
+getting it right here matters a lot.
 
-**Purpose:** train a reward model to score full `(prompt, response)` trajectories such
-that `r(chosen) > r(rejected)` in expectation.
+### 3.2 Preference dataset (for the reward model)
 
-- One example = `(prompt, chosen_response, rejected_response)` where `prompt` is the
-  shared prefix up to and including the last `<|im_start|>assistant\n` header before the
-  final turn.
-- Tokenize `prompt + chosen_response` and `prompt + rejected_response` **separately**.
-  You could be clever and share the prompt prefix in the forward pass, but don't — the
-  clarity is worth more than the throughput for a teaching impl.
-- Return attention masks and, for each of the two sequences, the index of the last real
-  (non-pad) token. The RM reads out its scalar reward at that position.
+**Purpose.** Train a reward model to assign a scalar "quality score" to a full
+`(prompt, response)` conversation. The loss asks that the score for the chosen response
+be higher than the score for the rejected response, on average.
+
+Each example holds `(prompt, chosen_response, rejected_response)`, where `prompt` is
+the shared prefix up through the last `<|im_start|>assistant\n` header (just before the
+response that differs).
+
+The simplest implementation tokenizes `prompt + chosen_response` and
+`prompt + rejected_response` as two separate sequences. You *could* be clever and
+share work on the prompt prefix, but don't — the extra compute isn't worth the loss of
+clarity for a teaching impl.
+
+For each of the two sequences you also return an attention mask and the index of the
+last real (non-pad) token. The RM reads off its scalar score at that index.
 
 ### 3.3 Prompt-only dataset (for PPO)
 
-**Purpose:** produce prompts that the current policy generates completions from, so we
-can score them with the RM and do policy updates.
+**Purpose.** Hand the policy a batch of prompts it hasn't seen yet, let it generate
+completions, then score those completions with the RM and update the policy. For this
+we need just prompts — no assistant answers attached.
 
-- One example = a prompt ending with `<|im_start|>assistant\n` (no assistant content yet).
-- Truncate / select prompts so that `len(prompt_tokens) <= 512` and we have budget for
-  `<= 256` generated tokens within the model's `block_size = 1024`.
-- **Left-pad** to max prompt length in the batch so that the "next token to predict"
-  position is aligned across the batch. (Right-padding would require per-sample offsets
-  during rollout.)
+Each example is a prompt ending with `<|im_start|>assistant\n` and nothing after. That
+header is the signal "your turn to talk, model".
+
+We want the full context (prompt + generated response) to fit inside GPT-2's 1024-token
+window. We split the budget: keep prompts to at most 512 tokens, and allow the model to
+generate up to 256 new tokens.
+
+**Left-pad** the prompts to the max length in the batch. Why left-pad instead of
+right-pad? Because generation starts at the *last* real position of the prompt. If we
+right-padded, the "last real position" would be at a different index for every row,
+and we'd have to index into each row separately. Left-padding puts every row's "next
+token to predict" at the same column, which is much simpler to handle in batched code.
 
 ---
 
 ## 4. Token budget
 
-GPT-2 small has a context window of 1024 tokens. Your budget across all three phases:
+GPT-2 small has a context window of 1024 tokens. So across all phases we need:
 
-$$T_\text{prompt} + T_\text{response} \le 1024.$$
+    prompt_tokens + response_tokens  <=  1024
 
-Default split: $T_\text{prompt} \le 512$, $T_\text{response} \le 256$. This leaves
-headroom and matches the PPO config. For SFT, full dialogues occasionally exceed 1024 —
-drop those examples or truncate from the left (keep the tail; assistant responses are
-what we care about).
+Our default split is:
+
+    prompt_tokens     <=  512
+    response_tokens   <=  256
+
+That leaves some headroom and matches the PPO config.
+
+During SFT, some full dialogues exceed 1024 tokens — these are rare but real. When you
+hit one, either drop the example or truncate from the **left** (keep the tail). The
+assistant's final response is what we actually want to train on, so never throw that
+away.
 
 ---
 
 ## 5. What to commit to `notes/00-data.md`
 
-Fill this file in as you run Problem 0.2:
+Fill this file in while you're doing Problem 0.2:
 
-- Train/test sizes
-- Turn-count histogram (e.g. "most examples have 1–2 human turns")
-- p50 / p95 / p99 token lengths of chosen, rejected, prompt-only
-- 3 verbatim samples (truncated if huge)
-- Any oddities you notice (malformed examples, duplicate pairs, etc.)
+- Number of train and test rows.
+- A quick histogram of turn counts ("most examples have 1–2 human turns").
+- p50 / p95 / p99 token lengths for chosen, rejected, and prompt-only.
+- Three verbatim samples (truncate if very long).
+- Any oddities you notice (malformed rows, duplicate pairs, weird formatting, etc.).
 
-This is your reference every time you later wonder "wait, how long is a typical
-response?" — don't skip it.
+This is your reference file. A month from now, when you're wondering "wait, how long is
+a typical response?", you'll come back to this file. Write it like you'll need to reload
+the dataset's shape into your head quickly.

--- a/notes/01-gpt2.md
+++ b/notes/01-gpt2.md
@@ -2,301 +2,342 @@
 
 ## Purpose
 
-This is the theory packet for Module 1 (Problems 1.1 through 1.8). Read through the whole
-thing once before you start typing, then re-read each section right before its problem.
-By the end of Module 1 you should be able to draw every forward and backward arrow of
-GPT-2 on a whiteboard without reference.
+This is the theory packet for Module 1 (Problems 1.1 through 1.8). Read through the
+whole thing once before you start typing, then re-read the relevant section right
+before each problem. By the end of Module 1 you should be able to draw every arrow —
+forward and backward — of GPT-2 on a whiteboard without looking anything up.
 
-All shapes use $B$ = batch, $T$ = sequence length, $C = n_\text{embd}$, $V$ = vocab size,
-$n_h$ = number of heads, $d_h = C / n_h$ = head dimension.
+Notation we'll use throughout:
+
+- `B` = batch size (number of sequences in parallel).
+- `T` = sequence length (number of tokens per sequence).
+- `C` = `n_embd` = width of the hidden state (e.g. 768 for GPT-2 small).
+- `V` = vocabulary size (50,257 for GPT-2).
+- `n_h` = number of attention heads (12 for small).
+- `d_h` = `C / n_h` = size of each head (64 for small).
 
 ---
 
 ## 1. Big picture
 
-GPT-2 is a **decoder-only causal transformer language model**. You feed in a sequence of
-tokens and it predicts the next token at every position *in parallel*:
+GPT-2 is a **decoder-only causal transformer language model**. "Decoder-only" means
+there's no separate encoder — just a single stack that reads and writes. "Causal"
+means a token at position `t` can only see tokens at positions `0, 1, ..., t` — it
+cannot peek at the future. "Language model" means the job is next-token prediction.
 
-$$
-\text{logits}_t = f_\theta(x_0, x_1, \dots, x_t)
-\quad \text{for } t = 0, 1, \dots, T-1.
-$$
+Here's the key idea. When you feed a sequence of `T` tokens into GPT-2, it produces
+`T` predictions in one forward pass — one prediction per position:
 
-"Causal" means position $t$ only sees positions $\le t$. "Parallel" means the whole
-sequence is processed in one forward pass and you get $T$ predictions at once — the
-causal mask is what enforces the autoregressive property without actually unrolling
-over time.
+- Position 0's output predicts the token at position 1.
+- Position 1's output predicts the token at position 2.
+- ...
+- Position `T-1`'s output predicts the token at position `T`.
 
-The stack:
+So training is parallel (one forward pass gives `T` training signals), but the model
+is constrained by the causal mask so that each prediction only depends on the tokens
+to its left. This is what "parallel training of an autoregressive model" means.
+
+The stack of operations:
 
 ```
 input_ids  (B, T)
-    -> token_embed      (B, T, C)
-    -> + pos_embed      (B, T, C)
-    -> [Block] x n_layer
-         - x = x + attn(LN(x))
-         - x = x + mlp (LN(x))
-    -> final LayerNorm  (B, T, C)
-    -> lm_head (tied)   (B, T, V)  = logits
+    -> token embedding lookup            (B, T, C)
+    -> + positional embedding lookup     (B, T, C)
+    -> transformer Block 1
+    -> transformer Block 2
+    ...
+    -> transformer Block n_layer
+    -> final LayerNorm                   (B, T, C)
+    -> project to vocabulary             (B, T, V)   = logits
 ```
 
-All residual connections are pre-LN (LayerNorm is applied **before** attention/MLP, not
-after). Post-LN is the original Transformer; pre-LN is what GPT-2 actually uses and it
-is more stable for deep stacks.
+Each transformer block has the shape:
+
+```
+x = x + attention(LayerNorm(x))
+x = x + mlp(LayerNorm(x))
+```
+
+Notice the LayerNorm happens **before** attention and MLP — this is called **pre-LN**.
+The original 2017 Transformer paper put LayerNorm *after* (post-LN), but pre-LN turned
+out to be more stable when you stack many layers. GPT-2 and every modern decoder uses
+pre-LN.
 
 ---
 
 ## 2. Embeddings (Problem 1.1)
 
-Two lookup tables, both learned:
+GPT-2 has two learned lookup tables:
 
-- **Token embedding** `wte`: shape $(V, C)$. Maps token id $\to$ $C$-dim vector.
-- **Positional embedding** `wpe`: shape $(T_\text{max}, C)$. Maps position $\to$ $C$-dim
-  vector. `T_max = block_size = 1024` for GPT-2.
+- **Token embedding** `wte`: shape `(V, C)`. Each row is the vector representation of
+  one token in the vocabulary.
+- **Position embedding** `wpe`: shape `(T_max, C)`. Each row is the vector that
+  represents "this is position 0 / position 1 / ..." in a sequence. For GPT-2,
+  `T_max = block_size = 1024`.
 
-Forward:
+The first layer of the model is just:
 
-$$
-h_t^{(0)} = \text{wte}[x_t] + \text{wpe}[t].
-$$
+    h_0[b, t] = wte[input_ids[b, t]] + wpe[t]
 
-Both are dense lookups (`nn.Embedding`), not one-hot-times-matrix multiplications.
+That's it. Two lookups, one elementwise add. Both tables are `nn.Embedding` modules —
+dense lookups, not one-hot multiplications.
 
-**Why learned positions, not sinusoidal?** GPT-2 predates RoPE / ALiBi. Learned absolute
-positional embeddings just work up to the fixed `block_size`; past that the model has
-never seen positions so it breaks. You cannot extend GPT-2 beyond 1024 tokens without
-re-training `wpe`.
+**Why are positions learned, not sinusoidal?** Fancier position encodings like RoPE
+and ALiBi came after GPT-2. At the time, learning a separate vector per position just
+worked, as long as you don't go past position `T_max`. The catch: if you try to feed
+GPT-2 a sequence longer than 1024 tokens, you hit a `wpe` row it's never seen and the
+model falls apart. So 1024 is a hard ceiling without retraining `wpe`.
 
 ---
 
 ## 3. LayerNorm (Problem 1.2)
 
-Applied independently at each position $t$ across the $C$ feature dimension:
+LayerNorm normalizes each token's hidden vector independently. "Independently" means:
+for each (batch, time) position, we look at the `C`-dimensional hidden vector at that
+position and normalize *within* it. We do not mix across batch or across time.
 
-$$
-\mu = \frac{1}{C}\sum_{c=1}^{C} x_c, \qquad
-\sigma^2 = \frac{1}{C}\sum_{c=1}^{C}(x_c - \mu)^2,
-$$
+Here's what it does in four steps:
 
-$$
-\hat{x}_c = \frac{x_c - \mu}{\sqrt{\sigma^2 + \epsilon}}, \qquad
-y_c = \gamma_c \hat{x}_c + \beta_c.
-$$
+1. Compute the **mean** of the `C` values.
+2. Compute the **variance** of the `C` values (using `C` in the denominator, i.e.
+   biased variance — *not* `C - 1`).
+3. Subtract the mean and divide by `sqrt(variance + eps)`. This gives a vector with
+   zero mean and unit variance.
+4. Multiply by a learned per-channel scale `gamma` and add a learned per-channel bias
+   `beta`.
 
-$\gamma, \beta \in \mathbb{R}^C$ are learned affine parameters. $\epsilon \approx 10^{-5}$
-is for numerical stability.
+The scale and bias (each of shape `(C,)`) let the network undo the normalization if
+that's what it wants — so we're really just *reparameterizing* the hidden state
+rather than forcing it into a particular shape.
 
-**What LayerNorm actually does.** It projects $x$ onto the $(C-1)$-dim subspace
-orthogonal to $\mathbf{1}$ (mean removal), then rescales it onto the unit sphere of
-that subspace (variance normalization), then lets a per-channel affine put it wherever
-it wants. The network gets a fresh "centered and scaled" input at every block, which
-is what prevents activation magnitudes from exploding or vanishing as depth grows.
+**Why normalize at all?** Deep networks have a nasty habit: activation magnitudes
+drift layer by layer. Some channel's variance doubles at each block, and 12 blocks
+later you have a numerical disaster. LayerNorm resets the activation scale at every
+block so the next block always sees a "reasonable" input.
 
-### Backward (enough to grad-check)
+### The backward pass
 
-The variance term couples all $C$ coordinates, so `dL/dx` depends on the full
-`dL/dy`. You don't need to memorize the closed form — `torch.autograd` handles it — but
-you **do** need to know that:
+You don't need to hand-code the LayerNorm backward — PyTorch's autograd handles it.
+But you should know:
 
-- $\partial y / \partial \gamma$ is simply $\hat{x}$, and $\partial y / \partial \beta$
-  is $1$. These give parameter grads.
-- $\partial y / \partial x$ involves three terms: direct ($\gamma / \sigma$),
-  mean-coupling, and variance-coupling.
+- The variance is computed across `C` values, so the gradient with respect to one
+  component of the input depends on *all* `C` components (they're coupled through the
+  mean and variance).
+- The gradient with respect to `gamma` is just the normalized input, and the gradient
+  with respect to `beta` is 1.
 
-In Problem 1.2 your job is only to **grad-check** your implementation against
-`torch.nn.LayerNorm` at fp64 on a small tensor. If the check passes, you can trust
-autograd to do the chain rule for you in the rest of the model.
+Your job in Problem 1.2 is to write LayerNorm from scratch and **gradient-check** it
+against `torch.nn.LayerNorm`. If the numbers match at fp64 on a small tensor, you can
+trust autograd to handle it inside the rest of the model.
 
-### Pitfalls
+### Easy things to get wrong
 
-- Normalize across the last dim, not the batch or time dim.
-- The variance must be **biased** (divide by $C$), not unbiased ($C-1$). PyTorch's
-  `F.layer_norm` uses biased.
-- `eps` is added *inside* the sqrt, not outside.
+- Normalizing across the wrong dimension (e.g. batch or time, not feature).
+- Using unbiased variance (dividing by `C - 1`). PyTorch's `F.layer_norm` uses biased.
+- Putting `eps` outside the square root instead of inside.
 
 ---
 
 ## 4. Causal self-attention (Problem 1.3)
 
-This is the heart of the architecture. Work through the derivation until the shapes are
-automatic.
+Attention is the core of the transformer. Read this until the moves feel mechanical.
 
-### 4.1 Q, K, V projection
+### 4.1 Produce Q, K, V
 
-A single linear `c_attn: C -> 3C` produces queries, keys, and values at once:
+Start with the hidden state `x` of shape `(B, T, C)`. Run it through one big linear
+layer that outputs `3C` features:
 
-$$
-[Q \; K \; V] = x \, W_{qkv} + b_{qkv}, \qquad W_{qkv} \in \mathbb{R}^{C \times 3C}.
-$$
+    qkv = x @ W_qkv + b_qkv        # shape (B, T, 3C)
 
-Then split along the last dim into three $(B, T, C)$ tensors and reshape each into
-$(B, n_h, T, d_h)$:
+Split `qkv` along the last dimension into three tensors — queries `Q`, keys `K`, and
+values `V` — each of shape `(B, T, C)`. Then reshape each into `(B, n_h, T, d_h)` so
+that the `n_h` heads are separated and each head has its own `d_h`-dim Q, K, V.
 
-$$
-Q_{b, i, t, :}, \; K_{b, i, t, :}, \; V_{b, i, t, :} \in \mathbb{R}^{d_h}
-$$
+One way to think about this: at every position and for every head, you have three
+length-`d_h` vectors — a "query" (what am I looking for?), a "key" (what do I
+represent?), and a "value" (what information do I carry?).
 
-where $i$ indexes heads.
+### 4.2 Attention scores
 
-### 4.2 Scaled dot-product attention (single head)
+For a single head, compute the dot product of every query with every key:
 
-For a single head:
+    S[t, s] = (Q[t] . K[s]) / sqrt(d_h)
 
-$$
-S_{t, s} = \frac{Q_t \cdot K_s}{\sqrt{d_h}} \quad \in \mathbb{R}^{T \times T}.
-$$
+`S` is shape `(T, T)`. Each entry `S[t, s]` tells us how much position `t` wants to
+attend to position `s`.
 
-Apply the causal mask: set $S_{t, s} = -\infty$ for $s > t$. Then softmax along the $s$
-axis:
+### 4.3 Causal mask
 
-$$
-\alpha_{t, s} = \frac{\exp(S_{t, s})}{\sum_{s'=0}^{t} \exp(S_{t, s'})}, \qquad \alpha_{t, s} = 0 \text{ for } s > t.
-$$
+We must prevent position `t` from looking into the future. Before softmax, set
+`S[t, s] = -infinity` for every `s > t`. After softmax, those positions become
+*exactly* zero (since `exp(-inf) = 0`) so no information leaks.
 
-Output at position $t$ is a weighted sum of the values:
+In PyTorch: build a lower-triangular mask of ones with `torch.tril`, flip the zeros to
+`-inf`, add to `S`. Or, easier, pass `is_causal=True` to
+`F.scaled_dot_product_attention`. The curriculum lets you use this one built-in for
+performance.
 
-$$
-o_t = \sum_{s=0}^{t} \alpha_{t, s} V_s.
-$$
+### 4.4 Softmax → attention weights
 
-### 4.3 Why $\sqrt{d_h}$?
+Apply softmax along the "keys" axis (the `s` dimension):
 
-If $Q, K$ have unit-variance components, the dot product $Q_t \cdot K_s$ has variance
-$d_h$ (sum of $d_h$ independent product terms). Without scaling, softmax argument
-magnitudes grow with $d_h$, pushing softmax into a regime where gradients vanish (one
-entry gets almost all the mass). Dividing by $\sqrt{d_h}$ keeps the pre-softmax values
-at unit scale.
+    alpha[t, s] = exp(S[t, s]) / sum over s' of exp(S[t, s'])
 
-### 4.4 Causal mask
+The result `alpha` has shape `(T, T)` and each row sums to 1. Each row is a
+probability distribution over "which earlier positions to attend to".
 
-Additive mask: $M_{t, s} = -\infty$ if $s > t$ else $0$. Add it to $S$ *before* softmax.
-`-inf` after softmax becomes $0$ — exact, not approximate.
+### 4.5 Weighted sum of values
 
-In PyTorch, use `torch.tril(torch.ones(T, T))` and fill the zeros with `-inf`, OR pass
-`is_causal=True` to `F.scaled_dot_product_attention` (the one "cheat" the curriculum
-allows).
+For each position `t`, mix the value vectors using `alpha` as the weights:
 
-### 4.5 Multi-head concat + output projection
+    o[t] = sum over s of alpha[t, s] * V[s]
 
-Run all heads in parallel, concatenate their outputs along the feature dim back to size
-$C$, then project:
+That's the attention output per head, shape `(T, d_h)`.
 
-$$
-\text{attn}(x) = (\text{concat heads})\, W_o + b_o, \qquad W_o \in \mathbb{R}^{C \times C}.
-$$
+### 4.6 Why divide by `sqrt(d_h)`?
 
-Each head learns its own "what to attend to" pattern; the output projection lets them
-mix their results.
+Suppose `Q` and `K` each have components with roughly unit variance. Then the dot
+product `Q[t] . K[s]` is a sum of `d_h` independent products, each with unit variance,
+so the total has variance `d_h` and standard deviation `sqrt(d_h)`. If we don't
+rescale, the logits going into softmax grow with head size, and softmax gets peaky —
+one entry eats all the probability and gradients vanish. Dividing by `sqrt(d_h)`
+keeps the softmax inputs at a well-behaved scale regardless of head size.
 
-### 4.6 Gradient sanity
+### 4.7 Multi-head: concat + output projection
 
-The whole block is differentiable and you get the backward for free. You still
-gradient-check it at fp64 on a tiny tensor in Problem 1.3. Things that break this
-check if you get them wrong:
+Running `n_h` heads in parallel gives us `n_h` outputs, each of shape `(T, d_h)`.
+Concatenate them along the feature dim back to `(T, C)`, then pass through one more
+linear layer `W_o` (shape `C × C`) to mix information across heads:
 
-- Forgot to scale by $\sqrt{d_h}$ (check passes — it's still differentiable — but the
-  numbers won't match HF).
-- Mask applied after softmax (the masked positions aren't exactly zero because softmax
-  over finite numbers can never be exactly zero).
-- Head reshape wrong: `(B, T, n_h, d_h)` vs `(B, n_h, T, d_h)`. The batched matmul
-  expects head axis before time axis.
+    attn_out = concat(heads) @ W_o + b_o
+
+### 4.8 Backward pass
+
+All of the above is differentiable and autograd handles the backward for free. You
+still gradient-check the whole block at fp64 on a small tensor in Problem 1.3.
+
+Common bugs that gradient-check still catches (or you'd hope it did):
+
+- Forgetting the `sqrt(d_h)` scale. Autograd still works, but your numbers won't match
+  Hugging Face's in the parity test later.
+- Applying the mask *after* softmax instead of before. Masked positions won't be
+  exactly zero anymore (softmax over finite numbers can't produce exact zero).
+- Messing up the head reshape order: `(B, T, n_h, d_h)` vs `(B, n_h, T, d_h)`. The
+  attention matmul needs the head axis to come before the time axis.
 
 ---
 
 ## 5. MLP (Problem 1.4)
 
-Per-position, two-layer feedforward with **4× expansion**:
+The MLP is per-position (no mixing across time) and two layers deep. The hidden
+dimension expands to `4*C` in the middle:
 
-$$
-\text{mlp}(x) = \text{GELU}(x W_1 + b_1)\, W_2 + b_2,
-$$
+    h1 = x @ W_1 + b_1           # (B, T, 4C)
+    h2 = GELU(h1)                # (B, T, 4C)
+    mlp_out = h2 @ W_2 + b_2     # (B, T, C)
 
-where $W_1 \in \mathbb{R}^{C \times 4C}$ and $W_2 \in \mathbb{R}^{4C \times C}$. No
-dropout at inference.
+No dropout at inference.
 
-**GELU** (Gaussian Error Linear Unit):
+### GELU
 
-$$
-\text{GELU}(x) = x \cdot \Phi(x)
-= \frac{x}{2}\Bigl(1 + \text{erf}\!\left(\tfrac{x}{\sqrt{2}}\right)\Bigr),
-$$
+GELU stands for "Gaussian Error Linear Unit". In plain terms it's a smoother version
+of ReLU: instead of a hard "zero if negative, x if positive" kink at zero, GELU
+transitions smoothly around zero, looking roughly like `x` times a soft gate that is
+close to 0 for very negative `x` and close to 1 for very positive `x`.
 
-where $\Phi$ is the standard normal CDF. This is the **exact** form. GPT-2 uses exact
-GELU, not the tanh approximation. PyTorch: `F.gelu(x, approximate='none')`.
+The exact definition uses the standard normal CDF (the probability that a standard
+normal is less than `x`):
 
-Why GELU over ReLU: smoother gradient near zero; mildly better language-modeling
-perplexity at matched compute. There's no deep reason; it's what Radford et al. chose.
+    GELU(x) = x * Phi(x)
+
+GPT-2 uses the **exact** GELU (via the error function). There's a tanh-based
+approximation popular in some models, but GPT-2 uses the exact form. In PyTorch that's
+`F.gelu(x, approximate='none')`.
+
+Why GELU? It mildly improves language modeling perplexity compared to ReLU and its
+gradient is smoother near zero. There's no deep reason — it's what Radford et al.
+happened to use.
 
 ---
 
 ## 6. Transformer block (Problem 1.5)
 
-Pre-LN residual pattern:
+One block combines LayerNorm, attention, a second LayerNorm, and the MLP, with
+residual connections around each sub-layer:
 
-$$
-x \leftarrow x + \text{attn}(\text{LN}_1(x)),
-$$
+```
+x = x + attention(LayerNorm_1(x))
+x = x + mlp(LayerNorm_2(x))
+```
 
-$$
-x \leftarrow x + \text{mlp}(\text{LN}_2(x)).
-$$
+Each block has its own two LayerNorms (each with its own learned scale and bias) and
+its own attention and MLP weights.
 
-Two LayerNorms per block — one before the attention sublayer, one before the MLP — each
-with its own $\gamma, \beta$.
+### Why pre-LN?
 
-### Why pre-LN
+With **pre-LN** (LayerNorm inside the residual branch), gradients can flow directly
+through the residual connections from the loss all the way back to the embeddings,
+since the residual path is just an identity. LayerNorm sits off to the side on the
+sub-layer branch, and doesn't block gradient flow.
 
-Consider a stack of $N$ blocks. With pre-LN, the residual stream $x$ grows roughly
-linearly with depth (each block adds a bounded-norm residual), but gradients flow
-through identity connections unimpeded. With post-LN, the LayerNorm sits *on* the
-residual path, so gradients must pass through a normalization at every block and
-training is more fragile at large depth. Every modern decoder stack uses pre-LN for
-this reason.
+With **post-LN** (LayerNorm after the add), every residual connection has a
+LayerNorm stacked on top, and gradients must pass through it at every block. For deep
+stacks this makes training much more fragile. All modern decoders use pre-LN.
 
 ---
 
 ## 7. Full GPT-2 and weight tying (Problem 1.6)
 
-Stack $n_\text{layer}$ blocks, apply a final LayerNorm, then project to vocabulary:
+Put it together: `n_layer` transformer blocks, one final LayerNorm, and a linear
+projection from `C` back out to `V` to give logits:
 
-$$
-\text{logits}_t = \text{LN}_\text{final}(h_t^{(N)})\, W_\text{head}^\top, \qquad W_\text{head} \in \mathbb{R}^{V \times C}.
-$$
+    logits = LayerNorm_final(x) @ W_head.T
 
-**Weight tying.** GPT-2 (and most decoder LMs) sets
-`lm_head.weight = wte.weight` — the output projection and the input embedding share the
-same $(V, C)$ matrix. In PyTorch this is a single tensor referenced from two modules;
-backward accumulates gradients into it from both sides. This cuts parameter count by
-$V \cdot C \approx 38$M for GPT-2 small, which is about a third of the total.
+`W_head` has shape `(V, C)`.
 
-No bias on the LM head.
+### Weight tying
 
-### Parameter count (sanity check)
+Here's a trick GPT-2 uses (and most decoder LMs use). The output projection `W_head`
+and the input embedding `wte` are the **same tensor**:
 
-For GPT-2 small:
+    lm_head.weight = wte.weight
 
-- `wte`: $V \cdot C = 50257 \cdot 768 \approx 38.6$M (shared with `lm_head`)
-- `wpe`: $T_\text{max} \cdot C = 1024 \cdot 768 \approx 0.8$M
-- Per block: $4 C^2$ (attn qkv + out) + $8 C^2$ (mlp) + $\sim 4 C$ (LN + bias)
-  $\approx 12 C^2 \approx 7.1$M
-- 12 blocks: $\approx 85$M
-- Final LN: negligible
-- **Total: $\approx 124$M**
+In PyTorch, it's one underlying tensor referenced by two modules. When you do a
+backward pass, gradients from both directions (embedding lookup and output projection)
+get accumulated into that one tensor.
 
-If your `sum(p.numel() for p in model.parameters())` lands within 1% of 124M on
-gpt2-small, you're probably correct.
+Why? Saves parameters (`V * C ≈ 38M` in GPT-2 small, which is about a third of the
+whole model), and the tied representation seems to help a bit with quality.
+
+The LM head has no bias.
+
+### Parameter count sanity check
+
+For GPT-2 small (`V = 50257`, `C = 768`, 12 layers):
+
+- `wte`: `V * C ≈ 38.6M` (shared with `lm_head`).
+- `wpe`: `1024 * 768 ≈ 0.8M`.
+- Per block: `~12 C^2 ≈ 7.1M` (attention is `4 C^2`, MLP is `8 C^2`, LayerNorms and
+  biases are negligible).
+- 12 blocks: about 85M.
+- Final LayerNorm: a few thousand parameters, rounding error.
+- **Total: roughly 124M**.
+
+If `sum(p.numel() for p in model.parameters())` is within 1% of 124M on GPT-2 small,
+you're probably correct.
 
 ---
 
 ## 8. Loading HuggingFace weights (Problem 1.7)
 
-This is the only step where you interact with the `transformers` library, and only to
-download the `.safetensors` file. You do **not** import `GPT2Model`; you map tensors by
-name into your own `nn.Module` tree.
+This is the only point in the whole course where we touch Hugging Face's
+`transformers` library. We use it only to download the `.safetensors` file. We do
+*not* import `GPT2Model` and we do *not* copy its forward pass. Instead, we load the
+raw weight tensors by name into our own modules.
 
 ### Name mapping
 
-HuggingFace GPT-2 uses names like:
+Hugging Face's GPT-2 uses parameter names like:
 
 ```
 transformer.wte.weight
@@ -310,93 +351,108 @@ transformer.h.{i}.mlp.c_proj.weight / .bias
 transformer.ln_f.weight / .bias
 ```
 
-Match each of these to the corresponding parameter in your model. Build an explicit
-`{hf_name: your_name}` dictionary and log any unmatched tensors; don't trust loops to
-"just work".
+Build an explicit Python dict mapping each HF name to the corresponding parameter name
+in your own model. Log anything that doesn't match, instead of trusting a loop to
+silently skip. Unmatched tensors are almost always the sign of a real bug.
 
 ### The Conv1D gotcha
 
-HuggingFace implements the four linear layers (`c_attn`, `c_proj` in each block, and
-`c_fc`, `c_proj` in the MLP) as a class called `Conv1D` (see
-`transformers/pytorch_utils.py`). It is functionally a linear layer but stores the
-weight as shape `(in_features, out_features)` — the **transpose** of what
-`nn.Linear` expects.
+Hugging Face's GPT-2 implements the four linear layers (`c_attn` and `c_proj` in each
+block's attention, `c_fc` and `c_proj` in each block's MLP) using a custom class called
+`Conv1D` (see `transformers/pytorch_utils.py`). It's functionally a `nn.Linear`, but
+the weight is stored with shape `(in_features, out_features)` — the **transpose** of
+what `nn.Linear` expects.
 
-So when you copy the weight tensor over, you must transpose:
+So when you copy the weight over, transpose it:
 
 ```python
 your_param.data.copy_(hf_weight.T)
 ```
 
-Do this for every `c_attn`, `c_proj`, `c_fc`. Biases are unaffected (1D). If you forget,
-your model will run and shapes will match but outputs will be garbage — a classic
-grad-check-passes-model-still-broken failure.
+Apply this to every `c_attn`, `c_proj`, `c_fc` weight. Biases are 1D and unaffected.
+
+Forget this transpose and your code will run, shapes will match, and outputs will be
+garbage. This is the classic case of "grad-check passes but the model is broken" —
+which is why the next step is a *direct parity test* against Hugging Face.
 
 ### Parity test
 
-Fix a prompt, run both your model and HF's model on it, and assert:
+Pick a fixed prompt, run both your model and HF's model on it, and check that the
+logits match to within a small tolerance:
 
-$$
-\max_{b,t,v} \bigl|\text{logits}^\text{yours}_{b,t,v} - \text{logits}^\text{HF}_{b,t,v}\bigr| < 10^{-4}.
-$$
+    max over (b, t, v) of |your_logit - hf_logit|  <  1e-4
 
-If it's not, the name map or Conv1D transpose is wrong. Bisect by comparing at
-successive layer outputs.
+If they don't match, your name map or the Conv1D transpose is wrong. Debug by
+comparing intermediate outputs layer by layer until you find where the mismatch
+starts.
 
-Log the name-map table into this file when you finish 1.7.
+Once it passes, log the name-map table into this notes file so future-you can find it
+fast.
 
 ---
 
 ## 9. Sampling (Problem 1.8)
 
-Autoregressive generation: feed in the prompt, take the last-position logits, sample one
-token, append, repeat.
+Generation is autoregressive: feed the prompt in, grab the logits from the last
+position, sample one token, append it to the sequence, and repeat. Here are the knobs
+you'll implement.
 
 ### Temperature
 
-$$
-p_v = \frac{\exp(\text{logits}_v / \tau)}{\sum_{v'} \exp(\text{logits}_{v'} / \tau)}.
-$$
+Before softmax, divide logits by `tau`:
 
-$\tau = 1$ is the training distribution; $\tau \to 0$ is argmax (greedy); $\tau > 1$
-flattens. The RLHF rollout phase uses $\tau = 1$ by default — lowering it biases the
-policy update toward high-probability tokens, which starves the policy of diverse
-exploration.
+    p[v] = exp(logit[v] / tau) / sum over v' of exp(logit[v'] / tau)
 
-### Top-$k$
+- `tau = 1`: matches the training distribution.
+- `tau -> 0`: approaches argmax (greedy, deterministic).
+- `tau > 1`: flattens the distribution, more diverse but more noise.
 
-Zero out all but the $k$ largest-logit tokens before softmax. Cheap, effective; $k = 40$
-or $k = 50$ is a reasonable default for text generation outside of RL.
+In our RLHF rollouts we use `tau = 1` by default. Lowering temperature during RL
+biases the policy update toward high-probability tokens, which starves it of
+exploration diversity.
 
-### Top-$p$ (nucleus)
+### Top-k
 
-Sort tokens by probability descending. Keep the smallest prefix whose cumulative
-probability $\ge p$, zero out the rest, renormalize. Adapts to the shape of the
-distribution (narrow when confident, wide when uncertain).
+Keep only the `k` largest-logit tokens before sampling. Set everything else to
+`-infinity`. Cheap, effective. For plain text generation, `k = 40` or `k = 50` is a
+reasonable default.
+
+### Top-p (nucleus)
+
+Sort the probabilities in descending order. Find the smallest set of tokens whose
+cumulative probability reaches `p` (e.g. 0.9). Zero out everything else and
+renormalize.
+
+Top-p adapts to the current distribution's shape: when the model is confident, few
+tokens cover the nucleus; when it's uncertain, more tokens are kept. Usually works
+better than top-k in practice.
 
 ### EOS handling
 
-When you sample the EOS token (or in our case `<|im_end|>`), you're done. For batched
-generation, mark that row as finished and continue generating on the rest; fill the
-finished row with a pad token (convention: reuse EOS).
+When you sample the EOS token (for us, `<|im_end|>`), that row is done. For batched
+generation, mark the row as finished and keep generating on the others, filling the
+finished row's future positions with a pad token (conventionally, EOS itself).
 
 ### KV cache
 
-**Skip for now.** A naive loop re-processes the entire prefix at every step
-($O(T^2)$ forwards, $O(T^3)$ FLOPs for the generation). A KV cache stores each block's
-$K$ and $V$ across steps so each new token is only $O(T)$. Add it to `generate()` in
-Module 4 *only if* PPO rollouts are unacceptably slow. Clarity first.
+**Skip this for now.** A naive generate loop reprocesses the entire prefix at every
+step — total cost is quadratic in `T`. A KV cache stores each block's `K` and `V`
+across steps so that each new token only costs `O(T)` work.
+
+We add a KV cache later in Module 4 *only if* PPO rollouts are unacceptably slow.
+Clarity wins over speed for the first pass.
 
 ---
 
 ## 10. What to commit to `notes/01-gpt2.md`
 
-After finishing Module 1, add to this file:
+After finishing Module 1, add the following to this file:
 
-- Your HF parameter name-map table (for the parity test in 1.7)
-- The exact `max_abs_diff` you achieved against HF
-- Parameter count as reported by your model
-- One paragraph on any surprise you hit during implementation
+- Your HF-to-yours parameter name-map table from 1.7.
+- The exact `max_abs_diff` you got against HF in the parity test.
+- The parameter count your implementation reports.
+- One paragraph on any surprise you hit during implementation — something that cost
+  you an afternoon. Future-you will thank current-you.
 
-Your notes are the thing you'll re-read a month from now. Write them so future-you can
-reload the whole architecture into memory in 10 minutes.
+Your notes are the thing you'll re-read in a month. Write them so that you can reload
+the whole architecture into your head in 10 minutes flat.

--- a/notes/02-sft.md
+++ b/notes/02-sft.md
@@ -2,28 +2,34 @@
 
 ## Purpose
 
-Theory for Module 2 (Problems 2.1 through 2.5). By the end of this you should be able
-to:
+This is the theory packet for Module 2 (Problems 2.1 through 2.5). By the end you
+should be able to:
 
-1. Write the SFT loss in equations (and explain every symbol).
-2. Derive the gradient of softmax + cross-entropy with respect to the logits by hand.
-3. Explain *exactly* what the `loss_mask` is masking out and why.
+1. Write down the SFT loss and explain what every piece of it means in words.
+2. Derive the gradient of softmax + cross-entropy with respect to the logits on a
+   blank page.
+3. Explain exactly which tokens the `loss_mask` zeros out and why.
 
-SFT is the easiest of the three phases, but the masking logic is critical to get right.
-A single off-by-one or inverted mask here will propagate through everything downstream.
+SFT is the easiest of the three training phases. But the masking logic is *critical*.
+A single off-by-one or inverted mask here will quietly corrupt every downstream phase
+(RM and PPO both assume SFT was done correctly).
 
 ---
 
 ## 1. What SFT actually does
 
-We have a pretrained GPT-2 that models $P(x_t \mid x_{<t})$ on raw web text. We want
-a model that generates **assistant turns** that imitate the `chosen` responses from
-HH-RLHF. SFT = continue training with the same next-token objective, but on formatted
-dialogue data, and **only count loss on assistant tokens**.
+We start with a pretrained GPT-2. GPT-2 models the probability of the next token
+given the previous tokens, trained on web text. What we want is a GPT-2 that, when
+given a user's message in our ChatML format, produces an assistant reply that looks
+like the `chosen` responses from HH-RLHF.
 
-Think of it as next-token-prediction with a mask: the model sees the full dialogue,
-but the loss only "asks" it to predict the assistant's tokens. The prompt tokens are
-there as context, not as targets.
+SFT = keep the same next-token prediction objective, but train on formatted dialogues
+instead of raw web text, and **only count the loss on assistant tokens**.
+
+The mental model: the model sees the entire dialogue, but during training we only
+"grade" it on its predictions of assistant tokens. It can look at user messages for
+context, but we never ask it "predict the next user token" — user text is input,
+assistant text is the target.
 
 ---
 
@@ -31,150 +37,156 @@ there as context, not as targets.
 
 ### 2.1 Tokenized example
 
-One example: a full formatted dialogue tokenized to a sequence $x = (x_0, x_1, \dots, x_{T-1})$.
-Alongside, a binary mask $m = (m_0, m_1, \dots, m_{T-1}) \in \{0, 1\}^T$ where
-$m_t = 1$ iff **the target at position $t$ is an assistant token**.
+One example is one full formatted dialogue, tokenized to a sequence
+`x = [x_0, x_1, ..., x_{T-1}]`.
 
-"Target at position $t$" is $x_{t+1}$ under the next-token convention — position $t$'s
-logits predict position $t+1$'s token. So really the mask is on the *predictee*. The
-cleanest way to write it is to shift the sequence and mask in the shifted frame:
+Alongside `x`, we have a binary mask `m` of the same length. `m[t] = 1` means
+"position `t` is part of an assistant turn's content", and `m[t] = 0` means
+"position `t` is user text, scaffolding, or padding".
+
+Because GPT-2 predicts the *next* token at each position, it's cleaner to work with
+the shifted version:
 
 ```
-input_ids   = x[:-1]     # positions 0..T-2
-labels      = x[1:]      # positions 1..T-1  (what we predict)
-loss_mask   = m[1:]      # 1 iff labels[t] is an assistant token
+input_ids   = x[:-1]      # positions 0 .. T-2, what we feed in
+labels      = x[1:]       # positions 1 .. T-1, what we try to predict
+loss_mask   = m[1:]       # 1 iff the token we're trying to predict is assistant
 ```
 
-From here on, "position $t$" refers to the shifted frame — so $\text{logits}_t$ predicts
-$y_t = \text{labels}_t$.
+From now on when we say "position `t`" we mean the shifted frame — so the model's
+logits at position `t` predict `labels[t]`, and `loss_mask[t]` tells us whether that
+prediction counts toward the loss.
 
 ### 2.2 Per-token cross-entropy
 
-At position $t$, the model outputs a vector of logits $z_t \in \mathbb{R}^V$. Convert to
-probabilities via softmax:
+At each position `t`, the model outputs a logit vector of length `V` (vocab size).
+Softmax converts logits to a probability distribution over the vocabulary:
 
-$$
-p_{t, v} = \frac{\exp(z_{t, v})}{\sum_{v'} \exp(z_{t, v'})}.
-$$
+    p[t, v] = exp(logit[t, v]) / sum over v' of exp(logit[t, v'])
 
-Cross-entropy with the true token $y_t$:
+The cross-entropy loss at position `t` is the negative log-probability the model
+assigns to the true next token `y_t = labels[t]`:
 
-$$
-\ell_t = -\log p_{t, y_t} = -z_{t, y_t} + \log \sum_{v'} \exp(z_{t, v'}).
-$$
+    ell[t] = -log p[t, y_t]
+           = -logit[t, y_t] + log(sum over v' of exp(logit[t, v']))
 
-The second form (logits minus log-sum-exp) is what you implement for numerical
-stability — never compute the softmax explicitly and then log it.
+The second form is what you actually compute — subtract the correct token's logit
+from the log-sum-exp of all logits. Never compute the softmax first and then take
+its log; that's numerically unstable.
 
 ### 2.3 Masked mean over the batch
 
-Summed over a batch of examples indexed by $(b, t)$:
+Summing across a batch of examples:
 
-$$
-\mathcal{L}_\text{SFT} = \frac{1}{N_\text{resp}} \sum_{b, t} m_{b, t} \cdot \ell_{b, t},
-\qquad N_\text{resp} = \sum_{b, t} m_{b, t}.
-$$
+    L_SFT = sum over (b, t) of { m[b, t] * ell[b, t] }  /  N_resp
 
-$N_\text{resp}$ is the total number of **assistant tokens** in the batch. Divide by that,
-not by $B \cdot T$ — otherwise the loss magnitude depends on how much prompt padding
-you happened to include, which is noise.
+where `N_resp = sum over (b, t) of m[b, t]` is the total number of assistant tokens
+in the batch.
+
+Dividing by `N_resp` (instead of by `B * T` or anything else) means the loss scale
+doesn't depend on how much padding happened to be in the batch. Padding tokens
+contribute zero to the numerator *and* zero to the denominator, so they don't pollute
+either side of the average.
 
 ---
 
 ## 3. Why mask the prompt?
 
-Two reasons.
+Two big reasons.
 
-### 3.1 It's the wrong distribution
+### 3.1 User text is not something we want the model to learn to generate
 
-User prompts are human input; we do not want the model to learn $P(\text{user} \mid \text{history})$.
-If you train on prompt tokens, the model wastes capacity memorizing prompt phrasings
-that, at inference, *we* provide — not the model. At best it's wasted capacity; at
-worst the model starts hallucinating user turns into its own output (the classic
-"Human: ... Assistant:" leakage failure).
+At inference time, **we** write the user's message — the model never has to
+generate user text. If we train on user tokens, the model wastes capacity memorizing
+human prompt phrasings, and worse, sometimes starts hallucinating "Human: ..." turns
+into its own output. This is the classic SFT failure mode where the model keeps
+inventing the other side of the conversation. Masking out user tokens prevents it.
 
-### 3.2 The loss scale is dominated by prompts
+### 3.2 The loss scale is dominated by the prompt
 
-In HH-RLHF, prompts are often longer than responses. If you don't mask, roughly 60–80%
-of the loss comes from prompt tokens and the training signal for the assistant tokens
-is drowned out. You'd see the loss decrease fast but the instruction-following behavior
-would barely improve.
+In HH-RLHF, prompts are often *longer* than responses. Without masking, maybe 60–80%
+of every example's loss is coming from the user's prompt tokens. The assistant's
+response — the part we actually care about — is a small fraction of the signal. You'd
+see training loss drop fast, but qualitatively the model barely gets better at
+responding in the ChatML format.
 
-### 3.3 What the mask includes
+### 3.3 Exactly which tokens the mask includes
 
-Include assistant **content tokens** and the assistant turn's `<|im_end|>`. Exclude:
+Include:
 
-- The `<|im_start|>assistant\n` header tokens (those are scaffolding the model doesn't
-  need to generate — they come from the template).
-- All user content and user's `<|im_start|>user\n` and `<|im_end|>`.
-- Any padding tokens.
+- The **content tokens of each assistant turn**.
+- The assistant turn's closing `<|im_end|>` — we want the model to learn when to
+  stop.
 
-The `<|im_end|>` at the end of an assistant turn **is** masked in — we want the model
-to learn *when to stop*.
+Exclude:
+
+- The `<|im_start|>assistant\n` header. That's scaffolding that comes from our
+  template, not something the model needs to emit.
+- All user tokens: the content, and the user's `<|im_start|>user\n` and `<|im_end|>`.
+- Any padding.
 
 ---
 
-## 4. Gradient of softmax cross-entropy (derive this)
+## 4. Gradient of softmax cross-entropy
 
-You must be able to produce this from a blank page. It's the one gradient every ML
-engineer memorizes, and it's foundational for the PPO surrogate later.
+You must be able to derive this from a blank page. It's the one gradient every ML
+engineer has memorized, and the PPO surrogate we build in Module 4 uses the same
+mechanics.
 
 ### 4.1 Setup
 
-Single position for now. Let $z \in \mathbb{R}^V$, $p = \text{softmax}(z)$, $y$ the
-target class. Loss $\ell = -\log p_y$.
+Fix one position for now. Let `z` be the length-`V` vector of logits and let `p` be
+the softmax of `z`. Let `y` be the index of the correct class. The loss at this
+position is:
+
+    ell = -log p[y]
+
+We want `d ell / d z` — the gradient of the loss with respect to the logits.
 
 ### 4.2 Softmax derivative
 
-For any $v, u$:
+For any two indices `v` and `u`:
 
-$$
-\frac{\partial p_v}{\partial z_u}
-= p_v \left(\delta_{v, u} - p_u\right),
-$$
+    d p[v] / d z[u] = p[v] * (delta(v, u) - p[u])
 
-where $\delta_{v, u} = 1$ if $v = u$ else $0$. Derive this by differentiating
-$p_v = e^{z_v} / \sum_{v'} e^{z_{v'}}$ and grouping.
+where `delta(v, u)` is 1 if `v == u` and 0 otherwise. You get this by differentiating
+`p[v] = exp(z[v]) / sum(exp(z))` and applying the quotient rule — worth doing once
+by hand.
 
-### 4.3 Chain rule for $\ell$
+### 4.3 Chain rule
 
-$$
-\frac{\partial \ell}{\partial z_u}
-= -\frac{1}{p_y} \cdot \frac{\partial p_y}{\partial z_u}
-= -\frac{1}{p_y} \cdot p_y(\delta_{y, u} - p_u)
-= p_u - \delta_{y, u}.
-$$
+    d ell / d z[u]  =  -1/p[y] * d p[y] / d z[u]
+                    =  -1/p[y] * p[y] * (delta(y, u) - p[u])
+                    =  p[u] - delta(y, u)
 
 So in vector form:
 
-$$
-\boxed{\; \frac{\partial \ell}{\partial z} = p - \mathbf{1}_{y} \;}
-$$
+    d ell / d z  =  p - onehot(y)
 
-where $\mathbf{1}_y$ is the one-hot vector at class $y$.
+Read this out loud: **"the gradient is the model's predicted distribution minus a
+delta spike on the correct class."**
 
-Interpretation: the gradient is "predicted distribution minus the delta on the true
-class". It *pushes mass onto the true class and away from everything else* in
-proportion to what the model currently predicts.
+Interpretation: the gradient subtracts probability mass from the true class and adds
+it to every other class, proportional to what the model currently predicts. A
+gradient step (minus this direction) pushes mass *toward* the correct class and *away
+from* every wrong class. Beautifully simple.
 
 ### 4.4 With the mask
 
-Across positions $t$ and with the mask:
+Across positions `t`, with the mask factored in:
 
-$$
-\frac{\partial \mathcal{L}_\text{SFT}}{\partial z_t}
-= \frac{m_t}{N_\text{resp}} \left( p_t - \mathbf{1}_{y_t} \right).
-$$
+    d L_SFT / d z[t]  =  (m[t] / N_resp) * (p[t] - onehot(y[t]))
 
-Three things to notice:
+Three things worth noticing:
 
-- The gradient at position $t$ is **exactly zero** when $m_t = 0$. Flipping the value
-  of a masked label anywhere in the sequence changes nothing — no loss contribution,
-  no gradient. This is what the "flip a masked token" unit test checks.
-- The denominator is $N_\text{resp}$, not $N_\text{resp} \cdot V$. The factor of $V$
-  doesn't appear because $p$ is a distribution (sums to 1), not $V$ independent
-  variables.
-- This gradient is what gets backpropagated through the `lm_head` into the transformer.
+- When `m[t] = 0`, the gradient at that position is exactly zero. Changing the label
+  at a masked-out position doesn't change the loss. This is exactly what the
+  "flip a masked token, loss unchanged" unit test checks.
+- The denominator is `N_resp`, not `N_resp * V`. There's no factor of `V` because
+  `p` is a proper probability distribution (sums to 1) — it's not `V` independent
+  scalars.
+- This is the gradient that flows from the loss into the `lm_head` and then
+  backpropagates through the rest of the transformer.
 
 ---
 
@@ -182,77 +194,99 @@ Three things to notice:
 
 ### 5.1 `sft_loss(logits, labels, loss_mask)` (Problem 2.2)
 
+Shapes:
+
 ```
-logits:    (B, T, V)
+logits:    (B, T, V)     float
 labels:    (B, T)        int64, already shifted
-loss_mask: (B, T)        float or bool
+loss_mask: (B, T)        float or bool (0 or 1)
 ```
 
-Reference implementation (concepts, not code):
+The implementation in three lines:
 
-1. `logp = log_softmax(logits, dim=-1)` — fused, stable.
-2. `nll = -logp.gather(-1, labels.unsqueeze(-1)).squeeze(-1)`  # shape (B, T)
-3. `loss = (nll * loss_mask).sum() / loss_mask.sum().clamp_min(1.0)`
+1. `logp = log_softmax(logits, dim=-1)` — numerically stable, computes log-softmax
+   in one pass.
+2. `nll = -logp.gather(-1, labels.unsqueeze(-1)).squeeze(-1)` — pick the
+   log-probability of the true label at each position. Shape `(B, T)`.
+3. `loss = (nll * loss_mask).sum() / loss_mask.sum().clamp_min(1.0)` — masked mean.
 
-Do **not** use `F.cross_entropy(..., ignore_index=-100)` and stuff `-100` into masked
-labels. The whole point of this course is that you handle the mask explicitly. The
-`ignore_index` trick hides the mask from you and is where subtle bugs live.
+**Do not** use `F.cross_entropy(..., ignore_index=-100)` and stuff `-100` into masked
+labels. The point of this course is that you manage the mask explicitly. The
+`ignore_index` trick hides it from you, which is exactly where subtle bugs live.
 
 ### 5.2 Gradient check (Problem 2.2)
 
 Two tests:
 
-1. **Analytic vs. centered-difference** at fp64 on a tiny tensor (e.g. $B=2, T=4, V=8$).
-   Compute the gradient w.r.t. logits both ways; relative error should be $< 10^{-5}$.
-2. **Mask flip invariance**: construct inputs, compute loss. Now change `labels[b, t]`
-   at any masked-out position to a different token id and recompute. The two losses
-   must be exactly equal. The gradient must also be identical element-wise.
+1. **Analytic vs. finite difference.** Use fp64 and a tiny tensor (say `B=2, T=4,
+   V=8`). Compute the gradient with respect to `logits` both ways: once by calling
+   `.backward()` on the loss, once by perturbing each logit component by `+eps` and
+   `-eps` and averaging. Relative error should be under `1e-5`.
+
+2. **Mask flip invariance.** Construct inputs, compute the loss, then change
+   `labels[b, t]` at any masked-out position to a different token id. The loss
+   must be exactly equal to the original, and the gradient must be elementwise
+   identical.
 
 ### 5.3 DataLoader (Problem 2.3)
 
-- Pad to the longest in the batch, not the block_size. Returning $(B, 1024)$ tensors
-  when the longest example is 300 tokens wastes 70% of compute.
-- Return `input_ids`, `labels`, `loss_mask`, `attention_mask` all at the same shape
-  $(B, T_\text{batch})$.
-- `attention_mask` is the position mask used by the transformer (1 on real tokens, 0
-  on padding). `loss_mask` is the assistant-token mask. They are different tensors and
-  neither implies the other.
+- Pad to the length of the longest example in the batch, not to the full
+  `block_size`. If your batch's longest example is 300 tokens but you pad to 1024,
+  you're wasting 70% of compute on padding.
+- Return four tensors, all with the same shape `(B, T_batch)`:
+  - `input_ids`
+  - `labels` (shifted input_ids)
+  - `loss_mask` (the assistant-token mask, shifted)
+  - `attention_mask` (the usual 1-on-real-tokens, 0-on-padding mask)
+- `attention_mask` and `loss_mask` are different things. `attention_mask` tells the
+  transformer where the real tokens are. `loss_mask` tells the loss which tokens
+  count. Neither implies the other.
 
 ### 5.4 Training loop (Problem 2.4)
 
 The boring-but-important parts:
 
-- AdamW with $\beta = (0.9, 0.95)$, $\text{wd} = 0.1$, **no weight decay on 1D
-  params** (LayerNorm gains/biases and all biases — partition them into a decay
-  group and a no-decay group). This is the karpathy-style param grouping.
-- Cosine LR to 10% of peak over the run, linear warmup of 200 steps from 0 to peak.
-- Gradient clipping at norm 1.0.
-- bf16 autocast for the forward; fp32 master copy and optimizer state.
-- Gradient accumulation: effective batch = `batch_size * accum_steps` — scale loss
-  by `1/accum_steps` before `.backward()` and only step the optimizer every
+- **AdamW** with `betas = (0.9, 0.95)`, `weight_decay = 0.1`, **no weight decay on
+  1D parameters**. In practice this means: LayerNorm scales and biases, plus all
+  biases, go into a "no-decay" group; everything else goes into a "decay" group.
+  This is the param grouping Karpathy used in nanoGPT and InstructGPT follows the
+  same pattern.
+- **Cosine learning rate schedule** from peak LR down to 10% of peak, with a linear
+  warmup of 200 steps from 0 up to peak.
+- **Gradient clipping** at max norm 1.0.
+- **bf16 autocast** for the forward pass, with fp32 master weights and optimizer
+  state.
+- **Gradient accumulation** to hit a larger effective batch. Scale the loss by
+  `1 / accum_steps` before `.backward()`, and only call `opt.step()` every
   `accum_steps` micro-steps.
 
-Run for 2 epochs on HH's `chosen` stream. Log train loss every step, eval loss every
-250 optimizer steps on a held-out split. Save `sft.pt`.
+Run for 2 epochs on HH's `chosen` stream. Log training loss every step, eval loss
+every 250 optimizer steps on a held-out split. Save `sft.pt` at the end.
 
 ### 5.5 What good looks like
 
-- Training loss drops from ~3.5 (base GPT-2 on chat-formatted HH) to ~1.5–2.0 by end
-  of epoch 2. Exact number depends on your tokenization and mask.
-- Qualitative eval (Problem 2.5): base GPT-2 rambles and leaks "Human:"; SFT model
-  produces a coherent single assistant turn that ends with `<|im_end|>`.
+- Training loss typically drops from around 3.5 (base GPT-2 seeing chat-formatted
+  text for the first time) down to roughly 1.5–2.0 by the end of epoch 2. Exact
+  numbers depend on your tokenization and mask — don't obsess over matching
+  someone else's loss.
+- In the qualitative eval (Problem 2.5), the base model will ramble, sometimes
+  invent "Human:" turns, or drift off-topic. The SFT model should produce a single
+  coherent assistant turn that ends cleanly with `<|im_end|>`.
 
-If train loss plateaus above 3.0 after the first few hundred steps, your mask is
-probably wrong (you're training on prompt tokens and the loss is dominated by noise).
+If your training loss plateaus above 3.0 after a few hundred steps, your mask is
+almost certainly wrong — you're either training on prompt tokens or masking out
+assistant tokens you shouldn't be.
 
 ---
 
 ## 6. What to commit to `notes/02-sft.md`
 
-After finishing Module 2, append:
+After finishing Module 2, add:
 
-- Your own re-derivation of the softmax-CE gradient (paper photo or typed).
-- The training/eval loss curves (or a description if no plots).
-- Observations from the qualitative side-by-side in 2.5 — what does base say on your
-  held-out prompts, what does SFT say? Where does SFT still fail? These observations
-  motivate why we need RLHF.
+- Your own re-derivation of the softmax cross-entropy gradient (photo of paper or
+  typed). You must be able to do this cold in a month.
+- Training and eval loss curves, or at least a short description ("loss dropped
+  from 3.6 to 1.8 over two epochs, flattening in the last 500 steps").
+- Observations from the side-by-side in 2.5. What does base GPT-2 say on your
+  held-out prompts? What does SFT say? Where does SFT still fail? Those failure
+  modes are exactly the motivation for RLHF in the next modules.

--- a/notes/03-rm.md
+++ b/notes/03-rm.md
@@ -2,187 +2,167 @@
 
 ## Purpose
 
-Theory for Module 3 (Problems 3.1 through 3.5). The reward model (RM) is the bridge
-between human preference data and the RL phase. It learns a scalar "how good is this
-assistant response" function from pairwise comparisons, so that in PPO we have a
-differentiable-enough reward to optimize.
+Theory packet for Module 3 (Problems 3.1 through 3.5). The reward model (RM) is the
+bridge between human preference data and the RL phase. We train it on pairs of
+completions that humans ranked against each other, so that in PPO we have a scalar
+"how good is this response?" function to optimize.
 
-By the end of this you should be able to:
+By the end of this note you should be able to:
 
-1. Write down the Bradley–Terry likelihood and derive its gradient.
-2. Explain why we use the softplus form for numerical stability.
-3. Explain why the RM is initialized from the SFT model, not from base GPT-2.
-4. Explain what "reward calibration" means and what you expect the histograms to look
-   like.
+1. Write down the Bradley–Terry loss and explain what every symbol means.
+2. Derive its gradient by hand.
+3. Explain why we use the `softplus` form for numerical stability.
+4. Explain why the RM is initialized from the SFT checkpoint, not from base GPT-2.
+5. Explain what "reward calibration" means and what you expect the score histograms
+   to look like.
 
 ---
 
 ## 1. The goal in one sentence
 
-Given a preference dataset of pairs $(y_c, y_r)$ where $y_c$ was chosen over $y_r$ by a
-human labeler, learn a scalar function $r_\phi(y)$ (where $y$ is a full
-prompt + response) such that $r_\phi(y_c) > r_\phi(y_r)$ in expectation.
+We have a preference dataset of pairs `(y_c, y_r)` — chosen and rejected completions.
+We want to learn a scalar function `r(y)` (where `y` is a full prompt + response)
+such that, on average, the chosen completion gets a higher score than the rejected
+one:
 
-We don't have absolute "quality scores" — only pairwise preferences. So we need a loss
-that takes pairs in and outputs *log-likelihood of the observed preference*. That's
-what Bradley–Terry gives us.
+    r(y_c) > r(y_r)     in expectation
+
+We don't have absolute "quality scores" — only pairwise rankings. So the loss can't
+be "predict the correct score". Instead, the loss has to be "predict that `y_c` was
+ranked above `y_r`". That's exactly what the Bradley–Terry model gives us.
 
 ---
 
-## 2. Bradley–Terry model
+## 2. The Bradley–Terry model
 
 ### 2.1 The model
 
-Assume there is a latent scalar quality $r(y)$ for every completion $y$. When a human
-compares two completions, they pick the one with higher latent quality, but noisily:
+Imagine that every completion `y` has some hidden "true quality" score `r(y)`. When
+a human compares two completions, they pick the one with higher true score, but they
+do it *noisily* — sometimes they pick the worse one, more often when the two are
+close in quality. Specifically, Bradley–Terry assumes:
 
-$$
-P(\text{human picks } y_c \text{ over } y_r) = \sigma\bigl(r(y_c) - r(y_r)\bigr),
-$$
+    P(human picks y_c over y_r) = sigmoid(r(y_c) - r(y_r))
 
-where $\sigma(x) = 1/(1 + e^{-x})$ is the logistic sigmoid. This is the Bradley–Terry
-pairwise model (Bradley & Terry, 1952; used for chess Elo, sports ratings, etc.). The
-difference $r(y_c) - r(y_r)$ is the *log-odds* of the observed preference:
+where `sigmoid(x) = 1 / (1 + exp(-x))`.
 
-$$
-\log \frac{P(c \succ r)}{P(r \succ c)} = r(y_c) - r(y_r).
-$$
+Check that this makes sense: if `r(y_c) >> r(y_r)`, sigmoid goes to 1 — the human
+almost always picks the chosen one. If the two scores are equal, sigmoid is 0.5 — a
+coin flip. And if `r(y_c) << r(y_r)`, sigmoid goes to 0 — the human rarely picks the
+"chosen" one (the labeler made a bad call, which happens).
 
-Note: $r$ is only identifiable up to an additive constant. $r(y) \to r(y) + C$ leaves
-all preferences unchanged. In practice the RM's mean reward wanders over training and
-that's fine — only differences matter.
+This model comes from Bradley & Terry (1952) and is the same math behind Elo ratings
+in chess or ranking systems in sports.
 
-### 2.2 Parametrize $r$ with a neural net
+One subtlety: the score `r(y)` is only defined up to an additive constant. If you
+add the same number to every completion's score, all the *differences* stay the
+same and so do all the predicted probabilities. We'll see this again in the
+gradient.
 
-$r_\phi(y)$ is the GPT-2 backbone applied to the token sequence $y$, with a linear head
-that reads a scalar off the hidden state at the **last non-pad position**:
+### 2.2 Parametrize `r` with a neural net
 
-$$
-r_\phi(y) = w^\top h^{(N)}_{|y|-1}(y) + b,
-$$
+We use a GPT-2 backbone (same architecture as Module 1) with one extra head on top —
+a single linear layer that outputs a scalar per position:
 
-where $h^{(N)}_t(y)$ is the final-layer hidden at position $t$ and $|y|$ is the
-(non-pad) length of $y$. One scalar per sequence; the whole transformer plus the
-linear head is trained.
+    r(y) = w @ h_final[last_real_token_index] + b
 
-Why the last position? Under causal attention, the hidden at position $t$ has attended
-to positions $\le t$, so only the *last* position has seen the entire sequence. Earlier
-positions have seen only a prefix and can't judge the full response.
+where `h_final[t]` is the final layer's hidden state at position `t`, and
+`last_real_token_index` is the index of the last non-padding token in the sequence.
 
-### 2.3 Loss: negative log-likelihood of the pair
+**Why the last position?** Because causal attention means the hidden at position `t`
+has only looked at positions `0, 1, ..., t`. Only the *last* position has seen the
+entire sequence. Earlier positions have missing information — they couldn't have
+judged the full response.
 
-Given a single preference example $(y_c, y_r)$:
+### 2.3 The loss
 
-$$
-\mathcal{L}_\text{BT} = -\log P(c \succ r) = -\log \sigma\bigl(r(y_c) - r(y_r)\bigr).
-$$
+For a single preference pair `(y_c, y_r)`, the loss is the negative log-probability
+(under the Bradley–Terry model) that the human would pick `y_c` — which, by
+assumption, they did:
 
-Averaged over a dataset of pairs. That's the whole loss.
+    L_BT = -log P(c preferred over r)
+         = -log sigmoid(r(y_c) - r(y_r))
 
----
-
-## 3. The softplus form (and why)
-
-Let $\Delta = r(y_c) - r(y_r)$. Then
-
-$$
--\log \sigma(\Delta)
-= -\log \frac{1}{1 + e^{-\Delta}}
-= \log(1 + e^{-\Delta}).
-$$
-
-Define
-
-$$
-\text{softplus}(x) = \log(1 + e^{x}).
-$$
-
-Then
-
-$$
-\mathcal{L}_\text{BT} = \text{softplus}(-\Delta) = \text{softplus}(r(y_r) - r(y_c)).
-$$
-
-This equivalent form is what you implement because:
-
-- For large positive $\Delta$ (the RM is very confident $c \succ r$): $e^{-\Delta}$
-  underflows to 0, and $\log(1 + 0)$ is stable and near 0. Good.
-- For large negative $\Delta$ (the RM is confidently wrong): the naive
-  $\log(1 + e^{-\Delta})$ sends $e^{-\Delta}$ to $+\infty$, which overflows in bf16.
-  But `F.softplus` applied to $-\Delta$ is implemented with branching that computes
-  $\max(-\Delta, 0) + \log(1 + e^{-|\Delta|})$, which is stable in both directions.
-
-Always use `F.softplus(r_r - r_c)` or the equivalent trick — never `-log(sigmoid(...))`.
+Average over the dataset. That's the whole loss.
 
 ---
 
-## 4. Gradient derivation (derive this)
+## 3. The `softplus` form (numerical stability)
 
-Let $\Delta = r_c - r_r$. $\mathcal{L} = -\log \sigma(\Delta)$.
+Define `Delta = r(y_c) - r(y_r)`. Some algebra on the negative log-sigmoid:
 
-### 4.1 Setup: sigmoid derivative
+    -log sigmoid(Delta)
+    = -log( 1 / (1 + exp(-Delta)) )
+    =  log( 1 + exp(-Delta) )
 
-$$
-\sigma'(x) = \sigma(x)(1 - \sigma(x)).
-$$
+The function `softplus(x) = log(1 + exp(x))` is a standard numerically-stable op. So:
 
-### 4.2 Gradient w.r.t. $\Delta$
+    L_BT = softplus(-Delta) = softplus(r(y_r) - r(y_c))
 
-$$
-\frac{\partial \mathcal{L}}{\partial \Delta}
-= -\frac{\sigma'(\Delta)}{\sigma(\Delta)}
-= -(1 - \sigma(\Delta))
-= \sigma(\Delta) - 1.
-$$
+Why prefer this form? Two cases:
 
-This lies in $(-1, 0)$: strictly negative, because reducing $\Delta$ makes the loss go
-*up*, so the gradient (which points in the direction of increase) is negative.
+- When `Delta` is large and positive (RM confidently says chosen is better): the
+  naive `log(1 + exp(-Delta))` has `exp(-Delta)` underflow to 0, giving
+  `log(1 + 0) = 0`. That's fine.
+- When `Delta` is large and negative (RM confidently wrong): `exp(-Delta)` blows up
+  to `+infinity` in bf16, and the naive form overflows. But `F.softplus` internally
+  uses a branching trick equivalent to `max(x, 0) + log(1 + exp(-|x|))` which is
+  stable from both sides.
 
-### 4.3 Chain to $r_c$ and $r_r$
+In code, always write `F.softplus(r_r - r_c)`. Never `-log(sigmoid(r_c - r_r))`.
 
-$\Delta = r_c - r_r$, so $\partial \Delta / \partial r_c = +1$ and
-$\partial \Delta / \partial r_r = -1$.
+---
 
-$$
-\frac{\partial \mathcal{L}}{\partial r_c} = \sigma(\Delta) - 1
-= -\bigl(1 - \sigma(\Delta)\bigr)
-= -\sigma(-\Delta),
-$$
+## 4. Gradient derivation
 
-$$
-\frac{\partial \mathcal{L}}{\partial r_r} = -(\sigma(\Delta) - 1)
-= 1 - \sigma(\Delta) = \sigma(-\Delta).
-$$
+Let `Delta = r_c - r_r`. The loss is `L = -log sigmoid(Delta)`.
 
-Or, symmetrically:
+### 4.1 Derivative of sigmoid
 
-$$
-\boxed{\;
-\frac{\partial \mathcal{L}}{\partial r_c} = \sigma(\Delta) - 1, \qquad
-\frac{\partial \mathcal{L}}{\partial r_r} = 1 - \sigma(\Delta).
-\;}
-$$
+A useful fact:
 
-### 4.4 Sanity checks
+    sigmoid'(x) = sigmoid(x) * (1 - sigmoid(x))
 
-- **Magnitudes equal, signs opposite.** $\partial \mathcal{L}/\partial r_c$ and
-  $\partial \mathcal{L}/\partial r_r$ sum to zero. Consistent with $r$ being
-  identifiable only up to an additive constant: shifting both $r_c$ and $r_r$ by the
-  same amount doesn't change $\Delta$ or the loss, so $\nabla \mathcal{L}$ has zero
-  component along the "shift everything equally" direction.
+Derive it once yourself by differentiating `1 / (1 + exp(-x))`.
 
-- **When the model is confident and correct** ($\Delta \gg 0$, $\sigma(\Delta) \to 1$):
-  both gradients vanish. The model has no work to do.
+### 4.2 Gradient with respect to `Delta`
 
-- **When the model is confident and wrong** ($\Delta \ll 0$, $\sigma(\Delta) \to 0$):
-  $\partial \mathcal{L}/\partial r_c \to -1$, $\partial \mathcal{L}/\partial r_r \to +1$.
-  Maximum signal in the right direction.
+    d L / d Delta  =  -sigmoid'(Delta) / sigmoid(Delta)
+                   =  -(1 - sigmoid(Delta))
+                   =  sigmoid(Delta) - 1
 
-- **When uncertain** ($\Delta \approx 0$, $\sigma \approx 0.5$):
-  gradients are $\pm 0.5$. Reasonable pressure.
+This sits in the interval `(-1, 0)` — it's always negative. That makes sense: the
+loss goes *down* when `Delta` goes up, so the gradient (pointing in the direction of
+loss increase) points the other way.
 
-This is exactly logistic regression; we're just parameterizing the two sides with a
-giant transformer.
+### 4.3 Chain rule to `r_c` and `r_r`
+
+Since `Delta = r_c - r_r`:
+
+    d Delta / d r_c = +1
+    d Delta / d r_r = -1
+
+So:
+
+    d L / d r_c  =  sigmoid(Delta) - 1
+    d L / d r_r  =  1 - sigmoid(Delta)
+
+### 4.4 Sanity checks on the gradient
+
+- **Equal magnitudes, opposite signs.** The two gradients sum to zero. That matches
+  our earlier observation that `r` is only identifiable up to an additive constant —
+  shifting both `r_c` and `r_r` by the same amount changes nothing, so the gradient
+  can't have any component in the "shift everything equally" direction.
+- **Confident and correct** (`Delta` very positive, `sigmoid(Delta) ~ 1`): both
+  gradients go to zero. The model has nothing to fix.
+- **Confident and wrong** (`Delta` very negative, `sigmoid(Delta) ~ 0`):
+  `d L / d r_c ≈ -1` and `d L / d r_r ≈ +1`. Maximum signal, pushing `r_c` up and
+  `r_r` down.
+- **Uncertain** (`Delta ≈ 0`, `sigmoid ≈ 0.5`): gradients are ±0.5. Reasonable
+  pressure.
+
+This is just logistic regression. The only twist is that the "inputs" are two giant
+transformer forward passes.
 
 ---
 
@@ -190,71 +170,80 @@ giant transformer.
 
 ### 5.1 Initialization: from SFT, not base
 
-The RM is `GPT` (from Module 1) with an extra `nn.Linear(n_embd, 1)` scalar head.
-**Load weights from `sft.pt`, not from the raw HF checkpoint.**
+The RM is your `GPT` model from Module 1 with an extra `nn.Linear(n_embd, 1)` head.
+**Load the backbone weights from `sft.pt`, not from the raw HF checkpoint.**
 
-Why SFT init?
+Why start from SFT?
 
-- The RM has to process prompt + assistant response, which is in the same chat format
-  as SFT training data. The SFT backbone is already fluent in chat tokens.
-- Bradley–Terry on raw GPT-2 would first have to teach the backbone chat structure
-  *through* the preference signal, which is weak and indirect.
-- Standard practice in InstructGPT and basically every public RLHF recipe.
+- The RM has to process prompt + assistant response, both in the ChatML chat format.
+  The SFT backbone has already seen chat format and is fluent in it; base GPT-2 has
+  not.
+- Bradley–Terry on a raw GPT-2 backbone would have to teach the model chat format
+  *through* preference signal alone, which is weak and indirect. Wasted compute.
+- This is the standard recipe in InstructGPT and essentially every public RLHF
+  codebase.
 
 ### 5.2 The scalar head
 
-- `nn.Linear(n_embd, 1, bias=True)`.
-- **Initialize small.** Default PyTorch init gives a scalar with variance $1/n_\text{embd}$
-  — fine. If you do something exotic like init to 0, the early gradient is tiny and
-  nothing trains; if you init too large, your first forward gives $\sim 100$-scale
-  rewards and training blows up. Default init is what you want.
-- The head is applied to *every* position in the forward pass (giving a
-  `(B, T, 1)` tensor), but the loss only uses the value at the last non-pad token for
-  each example. Storing per-token rewards wastes memory but is simpler — the PPO phase
-  also wants per-token-ish rewards so it's worth keeping the per-position output.
+Just `nn.Linear(n_embd, 1, bias=True)`.
+
+**Use the default PyTorch init.** That gives output variance of about
+`1 / n_embd`, so initial rewards are near zero with small spread. Resist the
+temptation to init the weights to zero (the first gradient will be tiny and nothing
+trains) or to init them large (the first forward gives rewards on the scale of
+hundreds and training blows up). Default is fine.
+
+The head is applied at *every* position in the forward pass, giving a tensor of
+shape `(B, T, 1)`. The loss only uses the value at the last real token of each
+example. This wastes a little memory but keeps the forward pass simple — and PPO
+will later want per-token-ish quantities from the same backbone, so keeping the
+per-position output is convenient anyway.
 
 ---
 
 ## 6. Preference dataset (Problem 3.2)
 
-For each HH row you need four tensors per side (chosen and rejected):
+Each HH row turns into one preference example. Per side (chosen and rejected) you
+need:
 
 ```
-chosen_ids     : (T_c,)       tokens of prompt + chosen_response
-chosen_mask    : (T_c,)       attention mask (all ones since we pad in the batch)
-rejected_ids   : (T_r,)       tokens of prompt + rejected_response
-rejected_mask  : (T_r,)       attention mask
+chosen_ids     : (T_c,)        tokens of prompt + chosen_response
+chosen_mask    : (T_c,)        attention mask (usually all ones, padding handled in batch)
+rejected_ids   : (T_r,)        tokens of prompt + rejected_response
+rejected_mask  : (T_r,)        attention mask
 ```
 
-Batch collation: pad chosen and rejected to `max(max(T_c), max(T_r))` within the
-batch. Record the **last-real-token index** per example so the head knows where to
-read the reward from. You end up with a batch shape $(B, T_\text{max})$ for each side
-and a $(B,)$ `last_idx` vector per side.
+When you batch these up, pad chosen and rejected to some shared max length. For each
+example, record the **index of the last real token** on each side — that's where the
+RM will read its scalar score.
 
-Concretely, in one training step:
+One training step looks like:
 
-1. Forward the backbone on `chosen_ids` → hiddens `(B, T, C)` → head → `(B, T, 1)`.
-2. Gather `r_c = rewards[b, last_idx_c[b], 0]` into a `(B,)` tensor.
-3. Same for `rejected_ids` → `r_r`.
+1. Forward the backbone on `chosen_ids`, get hiddens `(B, T, C)`, then run the head
+   to get `(B, T, 1)`.
+2. Gather `r_c = head_output[b, last_idx_c[b], 0]` into a `(B,)` tensor.
+3. Do the same for `rejected_ids` to get `r_r`, shape `(B,)`.
 4. `loss = F.softplus(r_r - r_c).mean()`.
-5. Backward; step.
+5. Backward, step.
 
-Two forward passes per pair is the wasteful-but-clear choice. Fused pair-forward with
-shared prompt tokens is a 2x speedup but obscures the logic — skip for this course.
+Yes, that's two forward passes per pair. You could share work on the prompt prefix
+and be twice as fast, but the code gets noticeably messier. Skip the optimization
+for this teaching impl.
 
 ---
 
 ## 7. Training loop (Problem 3.4)
 
-- Lower learning rate than SFT: `lr = 1e-5` is typical. The backbone came in already
-  tuned by SFT and we don't want to disturb it too much.
-- 1 epoch over the preference pairs is usually sufficient. More epochs often overfit
-  on HH; you'll see eval accuracy plateau or fall.
-- Batch size is smaller (each "example" is 2 sequences), use gradient accumulation to
-  hit effective batch 32–64 pairs.
-- Eval metric: **pairwise accuracy** on a held-out split — fraction of pairs where
-  $r_c > r_r$. Target: $\ge 65\%$. (Human agreement itself on HH is ~70%, so this is
-  near the ceiling.)
+- **Lower learning rate than SFT.** `lr = 1e-5` is typical. The SFT backbone is
+  already well-tuned for chat text; we want to nudge it, not restart it.
+- **One epoch over the preference pairs** is usually enough. More epochs tend to
+  overfit HH; you'll see eval pairwise accuracy plateau or even fall.
+- **Smaller batch size.** Each "example" is two sequences, so you'll want
+  gradient accumulation to hit an effective batch of 32–64 pairs.
+- **Eval metric: pairwise accuracy.** On a held-out split, count the fraction of
+  pairs where `r_c > r_r`. Target: at least 65%. For reference, human agreement
+  rate on HH is around 70%, so 65% is near the natural ceiling — there's a lot of
+  irreducible label noise in preference data.
 
 Save `rm.pt`.
 
@@ -262,60 +251,61 @@ Save `rm.pt`.
 
 ## 8. Reward calibration (Problem 3.5)
 
-### 8.1 What you plot
+### 8.1 What to plot
 
-On the held-out eval set, compute $r_c$ and $r_r$ for every pair. Plot two overlaid
-histograms (use `matplotlib.hist` with `alpha=0.5`):
+On the held-out eval set, compute `r_c` and `r_r` for every pair. Draw two
+overlapping histograms (`matplotlib.hist` with `alpha=0.5`):
 
-- distribution of $r_c$ (chosen rewards)
-- distribution of $r_r$ (rejected rewards)
+- Distribution of `r_c` (chosen rewards).
+- Distribution of `r_r` (rejected rewards).
 
 ### 8.2 What to expect
 
-- **Overlapping.** The distributions will overlap a lot — this is fine and expected.
-  The model is making pairwise decisions, not absolute ones. An individual chosen
-  response is not always higher-reward than an individual rejected one from a
-  *different* pair; that's allowed.
-- **Mean separation.** $\mathbb{E}[r_c] > \mathbb{E}[r_r]$ by some positive gap, order
-  unity.
-- **Not calibrated to absolute quality.** The RM scores are on an arbitrary scale. A
-  reward of $+3$ isn't meaningful in isolation; only differences are.
+- **Lots of overlap.** This is fine and expected. The RM is only trained to get the
+  *pairwise* ranking right, not to assign an absolute quality score. One pair's
+  chosen response can easily score lower than another pair's rejected response.
+- **Mean separation.** The average of `r_c` should be greater than the average of
+  `r_r`, by a small but real gap (order 1 in whatever units the RM converged to).
+- **Not calibrated to anything absolute.** The numerical scale of the RM is
+  arbitrary. An RM score of `+3` has no universal meaning — only differences are
+  meaningful.
 
-### 8.3 What to watch for
+### 8.3 Warning signs
 
-- **Bimodal reward distribution** (two distinct clusters for chosen or rejected): the
-  RM is separating some feature other than preference (e.g. response length). Log the
-  correlation between $r$ and response length — if it's strong ($\rho > 0.5$), the RM
-  has learned "longer = better" rather than the real preference signal. InstructGPT
-  handled this with reward-length calibration; we just note it.
-- **Exploding rewards over training** ($r$ magnitudes grow into the tens): fine as long
-  as the pairwise accuracy keeps improving; unhealthy if accuracy is plateauing and
-  magnitudes are still growing (pure overfitting to residual noise).
+- **Bimodal distributions** (two distinct clusters on either side): the RM might be
+  separating something unrelated to preferences. The classic failure mode is length
+  bias — the RM learns "longer = better" instead of the real signal. Compute the
+  correlation between score and response length. If it's above 0.5, you have a
+  length-bias problem. InstructGPT fixed this with a separate length-calibration
+  step; for this course, note it and move on.
+- **Rewards exploding over training** (magnitudes climb into the tens): fine if
+  pairwise accuracy is also improving, unhealthy if accuracy is plateauing and the
+  scores are still growing. The latter means the model is just overfitting to
+  residual noise in the labels.
 
 ---
 
 ## 9. Why this matters for PPO
 
-The RM's output is the terminal reward signal in PPO (`r_RM` multiplying the final
-token indicator). The policy's advantage estimates are built on top of it via GAE.
-Two things cascade:
+The RM's output becomes the terminal reward signal in PPO — the scalar that
+multiplies the "last token" indicator in the per-token reward. From there the
+policy's advantage estimates (via GAE) are built on top. Two things cascade:
 
-- **A miscalibrated or weak RM becomes a ceiling on policy quality.** If the RM can't
-  tell chosen from rejected better than chance, PPO has no signal.
-- **A gameable RM gets hacked.** The PPO policy is a giant function approximator with
-  a sophisticated search algorithm; if the RM assigns high reward to any cheap feature
-  (exclamation points, length, specific sycophantic phrases), the policy will find and
-  exploit that. We'll see this in Module 5 as *reward hacking*: reward goes up, KL
-  goes up faster, responses get worse. That's an RM problem as much as a PPO problem.
+- **A weak RM caps the policy quality.** If the RM can't tell chosen from rejected
+  better than chance, PPO has no signal to follow. The policy won't improve.
+- **A gameable RM gets gamed.** The PPO policy is a powerful function approximator
+  with a sophisticated search loop. If the RM assigns high score to any cheap
+  surface feature — exclamation points, length, specific phrases — the policy will
+  find and exploit it. In Module 5 we'll see this as "reward hacking": reward goes
+  up, KL goes up faster, responses get worse. That's partly an RM problem.
 
 ---
 
 ## 10. What to commit to `notes/03-rm.md`
 
-After finishing Module 3, append:
+After finishing Module 3, add:
 
-- Your own re-derivation of $\partial \mathcal{L}_\text{BT}/\partial r_c$ and
-  $\partial \mathcal{L}_\text{BT}/\partial r_r$.
-- Final pairwise accuracy achieved; training loss curve.
-- The histogram plot (or a text description of the shape).
-- Correlation between reward and response length, if non-trivial.
+- Your own re-derivation of the gradients `d L_BT / d r_c` and `d L_BT / d r_r`.
+- Final pairwise accuracy on eval.
+- The score histogram plot (or a description in words).
+- The correlation between score and response length, if non-trivial.

--- a/notes/04-ppo-gae.md
+++ b/notes/04-ppo-gae.md
@@ -2,169 +2,177 @@
 
 ## Purpose
 
-Theory for Problem 4.4 (and the conceptual backbone for all of Module 4). This file
+Theory packet for Problem 4.4 (and conceptual backbone for all of Module 4). This file
 covers:
 
-1. The policy gradient theorem.
+1. The policy gradient theorem — the central identity of RL.
 2. Why we subtract a baseline — variance reduction.
-3. The bias–variance spectrum between one-step TD and Monte Carlo returns.
-4. The GAE recursion that linearly combines them, and how to derive it from scratch.
-5. How to use GAE on *per-token* rewards for language generation.
+3. The bias–variance trade-off between one-step TD and full Monte Carlo returns.
+4. GAE, the recursion that lets us dial between those two extremes.
+5. How all of this plays out for per-token rewards on text.
 
-The closely related KL penalty and PPO policy loss have their own note files
-(`04-ppo-kl.md` and `04-ppo-policy.md`). Read those after this one.
+Related notes: `04-ppo-kl.md` (the KL penalty) and `04-ppo-policy.md` (the PPO
+clipped surrogate, value loss, entropy). Read those after this one.
 
 ---
 
 ## 1. Notation for RL on text
 
-Our "environment" is a single episode of assistant generation. For a given prompt $s_0$
-(which is a sequence of tokens), the policy $\pi_\theta$ rolls out a response token by
-token:
+Our "environment" is one episode of assistant generation. Given a prompt `s_0`
+(a sequence of tokens), the policy `pi_theta` generates a response token by token:
 
-- State at time $t$: $s_t = (\text{prompt}, a_0, a_1, \dots, a_{t-1})$ — everything the
-  model has seen so far.
-- Action at time $t$: $a_t$, the next token sampled from $\pi_\theta(\cdot \mid s_t)$.
-- Transition: deterministic. $s_{t+1} = s_t \circ a_t$ (concatenation).
-- Reward: given by a **reward signal** we construct from the RM and a KL penalty —
-  we'll define this in `04-ppo-kl.md`. For now treat $r_t$ as given per token.
-- Episode ends at $t = T$ when the policy emits `<|im_end|>` or hits the max response
-  length.
+- **State at time `t`**: `s_t = (prompt, a_0, a_1, ..., a_{t-1})` — everything the
+  model has seen and produced so far.
+- **Action at time `t`**: `a_t`, the next token, sampled from
+  `pi_theta(. | s_t)`.
+- **Transition**: deterministic. `s_{t+1} = s_t` with `a_t` appended.
+- **Reward**: a per-token signal `r_t` that we *construct* from the RM and a KL
+  penalty. We'll define this in `04-ppo-kl.md`. For now just take `r_t` as given.
+- **Termination**: the episode ends at time `T` when the policy emits `<|im_end|>`,
+  or when it hits the maximum response length.
 
-The objective:
+The objective is the expected total reward over a sampled trajectory:
 
-$$
-J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\sum_{t=0}^{T-1} \gamma^t r_t\right],
-$$
+    J(theta) = E_{tau ~ pi_theta} [ sum_t gamma^t * r_t ]
 
-where $\tau$ is a full trajectory and $\gamma \in [0, 1]$ is the discount. For text we
-use $\gamma = 1$: trajectories are short and we want credit assignment across the
-whole response.
+`gamma` is a discount factor in `[0, 1]`. For text RL we use `gamma = 1` — episodes
+are short, and we want credit assignment to flow across the entire response.
 
 ---
 
 ## 2. The policy gradient theorem
 
-### 2.1 Statement
+### 2.1 What it says
 
-$$
-\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\sum_t \nabla_\theta \log \pi_\theta(a_t \mid s_t) \cdot \hat G_t\right],
-$$
+The gradient of the expected return, with respect to the policy parameters `theta`,
+can be written as:
 
-where $\hat G_t$ is any unbiased estimate of $\mathbb{E}[\sum_{k \ge t} \gamma^{k-t} r_k]$,
-the return from $t$ onward. The simplest choice is the Monte Carlo return itself:
+    grad J = E_{tau ~ pi_theta} [ sum_t grad log pi_theta(a_t | s_t) * G_hat_t ]
 
-$$
-\hat G_t = \sum_{k=t}^{T-1} \gamma^{k-t} r_k.
-$$
+where `G_hat_t` is any unbiased estimate of "the return from time `t` onward",
+meaning `E[ sum over k >= t of gamma^{k-t} * r_k ]`. The simplest choice is the
+Monte Carlo return — just the actual cumulative reward we observed from time `t`:
 
-### 2.2 Where it comes from
+    G_hat_t = sum over k = t..T-1 of gamma^{k-t} * r_k
 
-Sketch of the derivation (do it in full on paper at least once):
+### 2.2 Where it comes from (sketch)
 
-- $J(\theta) = \sum_\tau p_\theta(\tau) R(\tau)$ where $R(\tau)$ is total return.
-- $p_\theta(\tau) = P(s_0) \prod_t \pi_\theta(a_t \mid s_t) P(s_{t+1} \mid s_t, a_t)$.
-  Only the $\pi_\theta$ terms depend on $\theta$.
-- $\nabla \log p_\theta(\tau) = \sum_t \nabla \log \pi_\theta(a_t \mid s_t)$.
-- Apply the log-derivative trick: $\nabla J = \mathbb{E}[\nabla \log p_\theta \cdot R]$.
-- Causality: action $a_t$ can only affect rewards at times $\ge t$, so you can replace
-  $R$ with $\hat G_t$ inside the sum.
+Do the full derivation on paper at least once. Sketch:
 
-### 2.3 What it means in practice
+- `J(theta) = sum over trajectories tau of p_theta(tau) * R(tau)`, where `R(tau)`
+  is the total return of the trajectory.
+- Factor the trajectory probability:
+  `p_theta(tau) = P(s_0) * product_t pi_theta(a_t | s_t) * P(s_{t+1} | s_t, a_t)`.
+  Only the policy factors depend on `theta`.
+- Take `log` and then `grad`: `grad log p_theta(tau) = sum_t grad log pi_theta(a_t | s_t)`.
+  The transition probabilities and initial state drop out because they don't depend
+  on `theta`.
+- Use the log-derivative trick: `grad J = E[ grad log p_theta(tau) * R(tau) ]`.
+- Apply causality: action `a_t` can only affect rewards from time `t` onward. So
+  inside the sum over `t`, we can replace the total return `R(tau)` with just the
+  return-to-go `G_hat_t` without changing the expectation.
 
-At every position $t$, for every token $a_t$ we sampled, we push its log-probability
-**up** in proportion to how good the resulting future was ($\hat G_t > 0$) or **down**
-if it was bad ($\hat G_t < 0$).
+### 2.3 What this means intuitively
 
-The policy gradient is intuitive and correct, but $\hat G_t$ (the Monte Carlo return)
-has very high variance — one trajectory's sum is noisy, and trajectories are
-expensive (each one requires a full rollout). Reducing variance without introducing
-bias is the whole game from here.
+At each position `t`, for the token `a_t` we actually sampled, we nudge the model to
+make that token *more likely* (positive gradient on its log-probability) if the
+future went well (`G_hat_t > 0`), and *less likely* if the future went badly. The
+size of the nudge is proportional to how much better or worse than zero the future
+was.
+
+That's it. That's the policy gradient. It's intuitive and correct.
+
+**But**: Monte Carlo returns `G_hat_t` are *very noisy*. A single trajectory's
+cumulative reward depends on many sampled tokens' worth of randomness. So even if
+our policy is good, the gradient estimate has huge variance. Lowering that variance
+without introducing bias is the whole game from here on.
 
 ---
 
-## 3. The baseline: advantage estimation
+## 3. Baselines and advantages
 
-Observation: for any function $b(s_t)$ that depends only on the state (not the action),
+Here's a nice fact. For any function `b(s_t)` that depends only on the state (not
+on the action we took):
 
-$$
-\mathbb{E}_{a_t \sim \pi}\!\left[\nabla \log \pi(a_t \mid s_t) \cdot b(s_t)\right] = 0.
-$$
+    E_{a ~ pi} [ grad log pi(a | s_t) * b(s_t) ]  =  0
 
-(Proof: $b$ pulls out of the expectation over $a_t$; what remains is
-$\mathbb{E}_a[\nabla \log \pi] = \nabla \mathbb{E}_a[1] = 0$.)
+Why? Because `b(s_t)` doesn't depend on `a`, so it pulls out of the expectation
+over `a`. What's left is `E_a[ grad log pi(a | s_t) ]`, which equals
+`grad E_a[ 1 ] = grad 1 = 0`.
 
-So subtracting $b(s_t)$ from $\hat G_t$ does not change the expected gradient. But it
-can drastically reduce variance — especially if $b(s_t)$ is close to
-$\mathbb{E}[\hat G_t \mid s_t]$. The "advantage":
+So we can *subtract* any state-dependent `b(s_t)` from our return estimate
+without changing the expected gradient:
 
-$$
-A_t = \hat G_t - V(s_t),
-$$
+    grad J  =  E[ sum_t grad log pi(a_t | s_t) * (G_hat_t - b(s_t)) ]
 
-where $V(s_t)$ is our *value estimate* — a learned function (the value head) that
-approximates $\mathbb{E}[\hat G_t \mid s_t]$. Intuitively: the advantage is "how much
-better did this action turn out than what I expected before I took it?" Subtracting
-the baseline removes the bulk of trajectory-level noise (e.g. "this prompt is just an
-easy one") and keeps only the action-specific signal.
+This is unbiased for any choice of `b(s_t)`. But a good choice of `b` can slash
+the variance of the estimator. The best choice is `b(s_t) = E[G_t | s_t]` — the
+expected return starting from state `s_t` — because subtracting it leaves behind
+only the *action-specific* deviation from the average.
 
-Variance-reduced policy gradient:
+We learn such a `b` with a neural network and call it the **value function**
+`V(s_t)`. The difference between the observed return and the expected return is
+called the **advantage**:
 
-$$
-\nabla_\theta J = \mathbb{E}\!\left[\sum_t \nabla \log \pi_\theta(a_t \mid s_t) \cdot A_t\right].
-$$
+    A_t = G_hat_t - V(s_t)
 
-This is still unbiased as long as $V$ is a function of state only.
+Read "advantage" literally: how much better (or worse) did this action turn out than
+what we expected before taking it?
+
+The variance-reduced policy gradient:
+
+    grad J = E[ sum_t grad log pi(a_t | s_t) * A_t ]
+
+Still unbiased. Much lower variance in practice. This is what every modern policy
+gradient algorithm uses.
 
 ---
 
 ## 4. TD error and the bias–variance spectrum
 
-Define the **one-step TD error** at time $t$ as:
+Before we define GAE, one more building block: the **one-step TD error**.
 
-$$
-\delta_t = r_t + \gamma V(s_{t+1}) - V(s_t).
-$$
+    delta_t  =  r_t + gamma * V(s_{t+1}) - V(s_t)
 
-This is "the part of the return I didn't expect": the actual reward plus the next
-state's value minus the current state's value.
+Read this as: "the reward I actually got, plus what the value function says is left
+to earn from the next state, minus what I had expected from this state". It's the
+part of the return at time `t` that wasn't predicted by the value function. (TD
+stands for "temporal difference".)
 
-Two extreme advantage estimators:
+We can build advantage estimators out of TD errors, and we can pick how many of
+them to use:
 
-### 4.1 One-step TD ($\lambda = 0$)
+### 4.1 One-step advantage
 
-$$
-A_t^{(0)} = \delta_t = r_t + \gamma V(s_{t+1}) - V(s_t).
-$$
+Use one TD error:
 
-- **Low variance** — depends on a single reward sample.
-- **High bias** — inherits any error in $V(s_{t+1})$. If $V$ is a bad estimate, so is
-  $A^{(0)}$.
+    A_t^(0) = delta_t
 
-### 4.2 Monte Carlo return ($\lambda = 1$)
+- **Low variance**: depends on only one reward sample.
+- **High bias**: relies heavily on `V(s_{t+1})` being accurate. If `V` is wrong, so
+  is this advantage.
 
-$$
-A_t^{(\infty)} = \sum_{k=t}^{T-1} \gamma^{k-t} r_k - V(s_t)
-= \sum_{k=t}^{T-1} \gamma^{k-t}\, \delta_k \cdot \text{(plus telescoping )}.
-$$
+### 4.2 Monte Carlo advantage
 
-(See derivation below.)
+Sum rewards all the way to the episode end:
 
-- **Zero bias** (doesn't use $V$ anywhere in the future; only as the baseline at
-  time $t$).
-- **High variance** — sums rewards over the whole tail.
+    A_t^(infinity) = sum over k = t..T-1 of gamma^{k-t} * r_k  -  V(s_t)
 
-### 4.3 n-step returns
+- **Zero bias**: doesn't trust `V` at all except as the baseline at time `t`.
+- **High variance**: the tail of rewards is noisy.
 
-For any $n$:
+### 4.3 n-step in between
 
-$$
-A_t^{(n)} = r_t + \gamma r_{t+1} + \dots + \gamma^{n-1} r_{t+n-1} + \gamma^n V(s_{t+n}) - V(s_t)
-= \sum_{k=0}^{n-1} \gamma^k \delta_{t+k}.
-$$
+You can also use `n` real rewards and then bootstrap:
 
-Mid-spectrum: bias falls off with $n$, variance grows with $n$. GAE lets us interpolate
-between all of these with a single knob $\lambda$.
+    A_t^(n) = r_t + gamma * r_{t+1} + ... + gamma^{n-1} * r_{t+n-1} + gamma^n * V(s_{t+n}) - V(s_t)
+            = sum over k = 0..n-1 of gamma^k * delta_{t+k}
+
+(The second line is a nice algebraic identity — check it by expanding the definition
+of `delta`. The intermediate `V` terms telescope.)
+
+As `n` grows, bias falls and variance rises. GAE gives us a single knob that slides
+smoothly between these choices.
 
 ---
 
@@ -172,138 +180,149 @@ between all of these with a single knob $\lambda$.
 
 ### 5.1 Definition
 
-GAE is an exponentially weighted average of the $A_t^{(n)}$ for all $n \ge 1$:
+GAE is an exponentially weighted average of the n-step advantages for all `n >= 1`.
+In terms of TD errors:
 
-$$
-A_t^{\text{GAE}(\gamma, \lambda)} = \sum_{k=0}^{\infty} (\gamma \lambda)^k \, \delta_{t+k}.
-$$
+    A_t^GAE  =  sum over k = 0, 1, 2, ... of (gamma * lambda)^k * delta_{t+k}
 
-- $\lambda = 0$: GAE collapses to the one-step TD error $\delta_t$.
-- $\lambda = 1$: GAE collapses to the Monte Carlo advantage (no bias, all variance).
-- $\lambda \in (0, 1)$: interpolate. Typical choice for text RL: $\lambda = 0.95$.
+The knob is `lambda` in `[0, 1]`:
 
-### 5.2 Deriving the recursion (do this by hand)
+- `lambda = 0`: GAE collapses to one-step TD, `A_t = delta_t`. Low variance, high
+  bias.
+- `lambda = 1`: GAE collapses to Monte Carlo. No bias, high variance.
+- `lambda` in between: smoothly interpolate. The standard choice for text RL is
+  `lambda = 0.95`.
 
-Split the sum at $k = 0$:
+### 5.2 Deriving the recursion
 
-$$
-A_t = \delta_t + \sum_{k=1}^{\infty} (\gamma \lambda)^k \delta_{t+k}
-    = \delta_t + (\gamma \lambda)\sum_{k=0}^{\infty}(\gamma \lambda)^k \delta_{t+1+k}
-    = \delta_t + \gamma \lambda \, A_{t+1}.
-$$
+This is the clever trick. Split off the first term of the sum:
 
-So
+    A_t = delta_t + sum over k = 1, 2, ... of (gamma*lambda)^k * delta_{t+k}
+        = delta_t + (gamma*lambda) * sum over k = 0, 1, ... of (gamma*lambda)^k * delta_{t+1+k}
+        = delta_t + (gamma*lambda) * A_{t+1}
 
-$$
-\boxed{\; A_t = \delta_t + \gamma \lambda\, A_{t+1}. \;}
-$$
+So the GAE advantage satisfies:
 
-Boundary condition: at the terminal time $T$, the episode ends, so $V(s_T) = 0$ by
-convention and $A_T = 0$.
+    A_t = delta_t + gamma * lambda * A_{t+1}
+
+Boundary condition: at the terminal time `T`, the episode is over, so `V(s_T) = 0`
+by convention and `A_T = 0`.
+
+This recursion runs *backwards* through time, from `T-1` down to `0`, and that's
+how we compute it in code.
 
 ### 5.3 Algorithm
 
 ```
-V_T = 0
-A_T = 0
+A[T]     = 0
+V[T]     = 0              # by convention
 for t = T-1, T-2, ..., 0:
-    delta_t = r_t + gamma * V_{t+1} * nonterm_{t+1} - V_t
-    A_t     = delta_t + gamma * lam * A_{t+1} * nonterm_{t+1}
+    delta_t = r[t] + gamma * V[t+1] * nonterm[t+1] - V[t]
+    A[t]    = delta_t + gamma * lambda * A[t+1] * nonterm[t+1]
 ```
 
-where `nonterm_{t+1} = mask[t+1]` (1 if position $t+1$ is real and the episode is not
-done there, 0 if it's padding or a post-EOS step). The `nonterm` factor is how you
-handle variable-length sequences in a batched loop.
+The `nonterm[t+1]` factor is how we handle variable-length sequences in a batched
+loop. It's 1 if position `t+1` is still part of the real episode, 0 if it's
+padding or beyond the end. When `nonterm = 0`, the bootstrap from the future is
+zeroed out.
 
 ### 5.4 Returns as value targets
 
-After computing advantages, compute the value regression target:
+After computing advantages, the value head needs a regression target. We use:
 
-$$
-R_t = A_t + V_t.
-$$
+    R_t = A_t + V_t
 
-This is the "bootstrapped Monte Carlo return" that's consistent with $A_t$: if $A_t$
-estimates the deviation from $V_t$ and $V_t$ estimates $\mathbb{E}[G_t]$, then
-$A_t + V_t$ estimates $G_t$ itself. The value head is trained to regress $V_t$ to
-$R_t$ (see `04-ppo-policy.md`).
+This is sometimes called the "bootstrapped Monte Carlo return". The reasoning: if
+`A_t` estimates "how much better the return was than we expected" and `V_t`
+estimates "what we expected", then their sum estimates the actual return.
 
-**Important:** $R_t$ is computed from $V_t$, but we treat $R_t$ as a
-**stop-gradient constant** inside the value loss. Otherwise the value head would be
-trying to make $V_t$ match something that depends on $V_t$ — a trivial and useless
-fixed point. In practice: detach the values before the GAE computation, or call GAE
-under `torch.no_grad()`. The `ppo_core.gae` function stays pure; the `train_ppo.py`
-driver is responsible for the no-grad context.
+**Important.** When training the value head, `R_t` is treated as a stop-gradient
+*constant*, even though we computed it from `V_t` just now. Otherwise the value
+head would be chasing its own tail — trying to make `V_t` match something that
+itself depends on `V_t`. Nothing would train.
 
-### 5.5 Unit test (from Problem 4.4)
+In practice: compute the advantages and returns under `torch.no_grad()` (or detach
+the values first). The `ppo_core.gae` function can stay pure; the `train_ppo.py`
+driver is responsible for wrapping it correctly.
 
-Hand-computed 3-step example: $T = 3$, `values = [0, 0, 0]`, `rewards = [1, 0, 0]`,
-`mask = [1, 1, 1]`, $\gamma = 1$, $\lambda = 1$.
+### 5.5 Unit test (Problem 4.4)
 
-- $\delta_2 = r_2 + \gamma V_3 - V_2 = 0 + 0 - 0 = 0$, $A_2 = 0$.
-- $\delta_1 = r_1 + \gamma V_2 - V_1 = 0 + 0 - 0 = 0$, $A_1 = 0 + 1 \cdot 0 = 0$.
-- $\delta_0 = r_0 + \gamma V_1 - V_0 = 1 + 0 - 0 = 1$, $A_0 = 1 + 1 \cdot 0 = 1$.
+Hand-computed 3-step example. Set `T = 3`, `values = [0, 0, 0]`,
+`rewards = [1, 0, 0]`, `mask = [1, 1, 1]`, `gamma = 1`, `lambda = 1`.
 
-So `advantages = [1, 0, 0]`, `returns = [1, 0, 0]`. This matches the comment in
-`ppo_core.gae`. Add a second test with a pad token in the middle — your implementation
-should treat the pad position's advantage as zero.
+Walking the recursion backwards:
+
+- `delta_2 = 0 + 0 - 0 = 0`, so `A_2 = 0`.
+- `delta_1 = 0 + 0 - 0 = 0`, so `A_1 = 0 + 1 * 0 = 0`.
+- `delta_0 = 1 + 0 - 0 = 1`, so `A_0 = 1 + 1 * 0 = 1`.
+
+Result: `advantages = [1, 0, 0]`, `returns = [1, 0, 0]`.
+
+Add a second test with a pad token in the middle — your implementation should
+handle the `nonterm` mask correctly, zeroing out the bootstrap at the pad
+position.
 
 ---
 
 ## 6. Per-token rewards for text
 
-In classical RL, $r_t$ is an environmental reward at each step. For text, we
-**construct** the per-token reward signal:
+In classical RL, the environment hands you a reward at every step. For text we
+have to *construct* the per-token reward ourselves:
 
-$$
-r_t = -\beta \cdot \text{KL}_t(\pi_\theta \| \pi_\text{ref}) + r_\text{RM}(y) \cdot \mathbf{1}_{t = T-1}.
-$$
+    r_t  =  - beta * KL_t(pi_theta || pi_ref)     +     r_RM(y) * (t == last_response_token)
 
-- A small **per-token KL penalty** that punishes the policy for moving too far from
-  the reference (SFT) model at every token.
-- A **terminal RM reward**, delivered as a single scalar at the last real token of the
-  response.
+Two pieces:
 
-See `04-ppo-kl.md` for why and what the $\text{KL}_t$ estimator looks like.
+- A small **per-token KL penalty** that punishes the policy for drifting from the
+  frozen reference (SFT) model at every step of the response.
+- A **terminal RM reward**, delivered as a single scalar at the last real token of
+  the response.
 
-Two consequences:
+See `04-ppo-kl.md` for the KL penalty details — why it's there, what estimator we
+use, and how it's computed.
 
-1. **The "reward" in GAE is not the RM score alone** — the KL penalty is baked in at
-   the per-token level, so the policy learns to trade off reward-seeking against
-   staying close to the SFT distribution *along the whole response*, not just at the end.
-2. **GAE propagates the terminal RM reward backward through the response.** $A_t$ at
-   an intermediate token reflects how much the terminal reward exceeded expectation,
-   minus the KL cost accumulated since. GAE's exponential weighting decides how much
-   credit each intermediate token gets.
+Two consequences worth understanding:
+
+1. **The per-token reward is not the RM score alone.** The KL penalty is baked in
+   at the per-token level, so the policy learns to trade off reward-seeking against
+   staying close to the SFT distribution *along the whole response*, not just at
+   the end.
+2. **GAE propagates the terminal RM reward backward through the response.** The
+   advantage at an intermediate token reflects how much the terminal reward
+   exceeded expectation, minus the KL cost accumulated since that point. GAE's
+   exponential weighting decides how much credit each intermediate token gets for
+   the final outcome.
 
 ---
 
 ## 7. Advantage normalization (Problem 4.8)
 
-Before feeding advantages into the PPO policy loss, normalize them across the *valid
-tokens* in the batch to zero mean and unit std:
+Before feeding advantages into the PPO policy loss, normalize them across valid
+tokens so they have mean 0 and std 1:
 
-$$
-\tilde A_t = \frac{A_t - \mu}{\sigma + \epsilon}, \qquad
-\mu = \frac{\sum_{b, t} m_{b, t} A_{b, t}}{\sum_{b, t} m_{b, t}}, \qquad
-\sigma^2 = \frac{\sum_{b, t} m_{b, t} (A_{b, t} - \mu)^2}{\sum_{b, t} m_{b, t}}.
-$$
+    mean = (sum over (b, t) of mask[b, t] * A[b, t])  /  sum(mask)
+    var  = (sum over (b, t) of mask[b, t] * (A[b, t] - mean)^2)  /  sum(mask)
+    A_tilde = (A - mean) / (sqrt(var) + epsilon)
 
-Why: keeps the effective learning rate scale-invariant to whatever absolute scale the
-RM is on. The PPO clip range $\varepsilon = 0.2$ assumes advantages of roughly unit
-scale; without normalization, a large-magnitude RM means every step hits the clip and
-no learning happens.
+Why? Because the PPO clip range (typically `epsilon = 0.2`) was chosen assuming
+advantages on roughly unit scale. If the RM happens to output rewards on the scale
+of 10 or 100, the advantages will be correspondingly huge, every step will hit the
+clip, and no learning happens. Normalizing makes the effective learning rate
+invariant to the absolute scale the RM happens to have learned.
 
-**Crucially** compute $\mu$ and $\sigma$ using only the mask's 1-positions. Pad tokens
-are garbage data — they must not pollute the stats. The test in Problem 4.8 inserts
-huge garbage values at masked positions and checks the normalized stats are unchanged.
+**The mask matters.** Compute the mean and variance only over the positions where
+the mask is 1 — the real response tokens. Padding tokens are garbage data, and if
+you let them into the stats, they'll pollute the normalization. The unit test in
+Problem 4.8 inserts huge garbage values at masked positions and asserts that the
+normalized output's mean and std are unchanged.
 
 ---
 
 ## 8. What to commit to `notes/04-ppo-gae.md`
 
-After finishing Problem 4.4 and 4.8, append:
+After finishing Problems 4.4 and 4.8, add:
 
-- Your own derivation of the GAE recursion (the 5.2 step).
+- Your own derivation of the GAE recursion (section 5.2 above, redone by hand).
 - The numeric output of your unit tests, including the pad-in-the-middle case.
-- A one-line explanation of what $\lambda$ does (you should be able to say this cold).
+- A one-line explanation of what `lambda` does. You should be able to say this
+  without any hesitation.

--- a/notes/04-ppo-kl.md
+++ b/notes/04-ppo-kl.md
@@ -2,227 +2,224 @@
 
 ## Purpose
 
-Theory for Problems 4.2 and 4.3 (per-token KL and reward shaping). Short file, but the
-KL term is the single biggest source of "wait, why is this training unstable" problems
-in PPO for text. Read carefully.
+Theory packet for Problems 4.2 and 4.3 (per-token KL and reward shaping). Short note,
+but the KL term is the single biggest cause of "why is PPO unstable?" problems on
+text. Read carefully.
 
 By the end you should be able to:
 
-1. Explain why we want a KL penalty at all.
-2. Derive three estimators of $\text{KL}(\pi \| \pi_\text{ref})$ from a single sample:
-   $k_1$, $k_2$, $k_3$.
-3. Explain which to use for the penalty and which for logging, and why.
+1. Say why the KL penalty is there at all.
+2. Derive three single-sample estimators of KL divergence (`k_1`, `k_2`, `k_3`).
+3. Explain which estimator we use for the reward penalty, which we use for logging,
+   and why.
 4. Write down the per-token reward shaping used in InstructGPT-style PPO.
 
 ---
 
 ## 1. Why a KL penalty?
 
-The reward model $r_\phi$ is an imperfect proxy for human preferences. If we optimize it
-naively with a powerful policy, the policy will find *adversarial high-reward outputs*
-the RM assigns reward to but humans don't actually like — sycophancy, fake confidence,
-specific phrasing fingerprints. This is **reward hacking**.
+The reward model is an imperfect proxy for human judgment. If we optimize it
+naively with a strong policy, the policy will find *adversarial high-reward
+outputs* — text the RM scores high but humans actually dislike. Think sycophantic
+phrasing, confident-sounding nonsense, or specific fingerprints the RM happens to
+love. This failure mode is called **reward hacking**.
 
-Remedy: penalize the policy for moving too far from its starting point (the SFT model),
-measured in KL divergence token-by-token:
+The fix: penalize the policy for wandering too far from where it started (the SFT
+model), measured in KL divergence. The RL objective becomes:
 
-$$
-J_\text{RLHF}(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}\!\left[ r_\phi(\tau) - \beta \sum_t \text{KL}\bigl(\pi_\theta(\cdot \mid s_t) \,\|\, \pi_\text{ref}(\cdot \mid s_t)\bigr)\right].
-$$
+    J_RLHF(theta) = E [ r_RM(trajectory) - beta * sum over t of KL( pi_theta(. | s_t) || pi_ref(. | s_t) ) ]
 
-$\beta$ controls how conservative the policy stays. Small $\beta$ = free to explore,
-big reward-hacking risk. Large $\beta$ = stays close to SFT, smaller reward gains.
+`beta` controls the strength of the penalty:
 
-Two interpretations of this penalty, both valid and important:
+- Small `beta`: policy is free to explore, but reward-hacking risk is high.
+- Large `beta`: policy stays close to SFT, but reward gains will be small.
 
-- **Trust region.** $\beta$ implements a soft trust region keeping $\pi_\theta$ in a
-  neighborhood of $\pi_\text{ref}$ where the RM's judgments are more likely to be
-  accurate (because that's where the RM was trained).
-- **Regularization.** The SFT policy is the prior; we're doing
+Two different ways to understand this penalty, both true:
+
+- **Trust region.** `beta` implements a soft trust region that keeps `pi_theta`
+  in a neighborhood of `pi_ref`, where the RM's judgments are more likely to be
+  reliable (because that's where the RM was trained).
+- **Regularization toward a prior.** The SFT policy is our prior. We're doing
   reward-maximization-with-a-prior rather than pure reward-maximization. You can
-  view PPO-with-KL-penalty as roughly the posterior under this prior.
+  view the PPO-with-KL objective as approximating the posterior under that prior.
 
-$\pi_\text{ref}$ is **frozen** (a copy of `sft.pt`). It does not get updated during PPO.
-
----
-
-## 2. Why a per-token KL at all (not episode-level)?
-
-We *could* compute a single full-sequence KL per episode and add it as one more scalar
-reward at the end. InstructGPT chose to distribute the KL penalty per-token instead:
-
-$$
-r_t = -\beta \cdot \text{KL}_t + r_\text{RM} \cdot \mathbf{1}_{t = T-1}.
-$$
-
-Advantages of per-token:
-
-- **Credit assignment.** Any individual token that drives up KL gets penalized at that
-  position, and GAE carries the signal backward only as far as reasonable. With an
-  episode-level penalty, every token in the sequence shares the blame equally.
-- **Numerical scale.** An episode-level KL is the sum of per-token KLs; over 256 tokens
-  that's a much larger scalar and makes tuning $\beta$ harder.
+`pi_ref` is a **frozen copy of `sft.pt`**. It never gets updated during PPO.
 
 ---
 
-## 3. The three KL estimators
+## 2. Why *per-token* KL, not per-episode?
 
-We have $\log \pi_\theta(a_t \mid s_t)$ (the "new" log-prob) and
-$\log \pi_\text{ref}(a_t \mid s_t)$ (the frozen ref's log-prob), both evaluated on the
-*sample* $a_t$ drawn from $\pi_\theta$ during rollout. We want an estimate of
+Option A: compute a single KL per episode and tack it onto the final reward.
+Option B: distribute the KL penalty across tokens, one per step.
 
-$$
-\text{KL}\bigl(\pi_\theta(\cdot \mid s_t)\,\|\,\pi_\text{ref}(\cdot \mid s_t)\bigr)
-= \mathbb{E}_{a \sim \pi_\theta}\!\left[\log \frac{\pi_\theta(a)}{\pi_\text{ref}(a)}\right]
-$$
+InstructGPT picks option B. The per-token reward becomes:
 
-from the single sample $a_t$ we actually drew.
+    r_t = -beta * KL_t + r_RM * (t == last_response_token)
 
-Define the log-ratio
+Two reasons this is better:
 
-$$
-L_t = \log \pi_\theta(a_t \mid s_t) - \log \pi_\text{ref}(a_t \mid s_t), \qquad
-\rho_t = e^{L_t}.
-$$
+- **Credit assignment.** If one specific token drives up the KL, it gets punished
+  at that position. GAE then propagates the penalty only as far backward as
+  reasonable. With an episode-level penalty, every token shares the blame
+  equally, which washes out the signal.
+- **Numerical scale.** Per-episode KL is the sum of per-token KLs. Over 256
+  tokens that's a much bigger scalar and makes `beta` much harder to tune.
 
-### 3.1 $k_1$: naive log-ratio
+---
 
-$$
-k_1(a_t) = L_t.
-$$
+## 3. Three KL estimators
 
-- **Unbiased** estimator of the KL:
-  $\mathbb{E}_{a \sim \pi_\theta}[L] = \text{KL}(\pi_\theta \| \pi_\text{ref})$ by definition.
-- Can be **negative** on a single sample (e.g. if the draw happens to be more likely
-  under $\pi_\text{ref}$ than $\pi_\theta$).
-- **High variance** — this is the "raw" estimator with nothing to reduce noise.
+Here's the setup. During rollout, we generated a sequence of tokens from
+`pi_theta`. For each generated token `a_t`, we have two numbers:
 
-This is what InstructGPT uses as the shaping penalty in the per-token reward.
+- `log pi_theta(a_t | s_t)`: the log-probability the current policy assigned.
+- `log pi_ref(a_t | s_t)`: the log-probability the frozen reference assigned.
 
-### 3.2 $k_2$: half-squared
+We want to estimate the KL divergence between the two policies *at that state*,
+defined as:
 
-$$
-k_2(a_t) = \tfrac{1}{2} L_t^2.
-$$
+    KL( pi_theta(. | s_t) || pi_ref(. | s_t) )
+      = E_{a ~ pi_theta} [ log pi_theta(a | s_t) - log pi_ref(a | s_t) ]
 
-- Always $\ge 0$.
-- **Biased**: $\mathbb{E}[k_2] \ne \text{KL}$ in general. It's a biased estimate of a
-  related but different quantity (it's actually an unbiased estimate of
-  $\tfrac{1}{2}\mathbb{E}[L^2]$, which by Jensen's is an upper bound on
-  $\tfrac{1}{2}(\mathbb{E} L)^2$ but not equal to $\text{KL}$).
-- Rarely used in modern RLHF. Included for completeness.
+But we don't have access to the full distribution or an exact expectation. We have
+exactly one sample `a_t` drawn from `pi_theta`. What's our best single-sample
+estimate?
 
-### 3.3 $k_3$: Schulman's unbiased-nonnegative
+Define the log-ratio for the token we drew:
 
-$$
-k_3(a_t) = \bigl(\rho_t - 1\bigr) - L_t = e^{L_t} - 1 - L_t.
-$$
+    L_t  =  log pi_theta(a_t | s_t) - log pi_ref(a_t | s_t)
+    rho_t = exp(L_t)
 
-- **Always $\ge 0$.** Because $e^x - 1 - x \ge 0$ for all real $x$, with equality only
-  at $x = 0$.
-- **Unbiased** estimator of $\text{KL}$.
+Three standard estimators, `k_1`, `k_2`, `k_3`:
 
-  Sketch: $\mathbb{E}_{a \sim \pi_\theta}[\rho - 1] = \mathbb{E}[\pi_\text{ref}(a)/\pi_\theta(a) \cdot \pi_\theta(a)/\pi_\text{ref}(a)]$ — wait, let's redo carefully.
+### 3.1 `k_1`: the naive log-ratio
 
-  $\rho = \pi_\theta / \pi_\text{ref}$, so
-  $\mathbb{E}_{\pi_\theta}[\rho - 1] = \mathbb{E}_{\pi_\theta}[\pi_\theta/\pi_\text{ref}] - 1$.
-  That second expectation is not 1 in general — it's
-  $\sum_a \pi_\theta^2(a) / \pi_\text{ref}(a) \ge 1$. So $\mathbb{E}[\rho - 1] \ge 0$
-  but isn't zero.
+    k_1 = L_t
 
-  However, $\mathbb{E}[k_3] = \mathbb{E}[\rho - 1] - \mathbb{E}[L] = (\text{something} \ge 0) - \text{KL}$.
+- **Unbiased**: `E[L_t]` under `pi_theta` is literally the KL, by definition. Good.
+- Can go **negative** on a single sample. If we happen to draw a token that the
+  reference thinks is more likely than the current policy does, `L_t < 0`. That's
+  weird-looking for a "divergence" but mathematically fine.
+- **High variance.** Single-sample estimator with no variance reduction.
 
-  The precise statement (Schulman 2020, "Approximating KL Divergence") is that $k_3$
-  is an unbiased estimator of a particular quantity that coincides with
-  $\text{KL}$ when one integrates properly — in practice $k_3$ is treated as "unbiased
-  for all intents and purposes" because it matches the true KL in expectation under
-  the regime we care about (moderate $\rho$). It's the standard estimator for logging.
+This is what InstructGPT uses as the shaping penalty in the per-token reward. It's
+exactly what we use in `shape_reward`.
 
-- **Lower variance than $k_1$** in practice, because the negative samples in $k_1$
-  get offset by the positive $\rho - 1 - L$ adjustment.
+### 3.2 `k_2`: half-squared log-ratio
 
-A clean intuition: $k_1$ is "the log-ratio of the sample I drew". $k_3$ adjusts that
-by how much $\rho$ departs from 1 *linearly* — penalizing both upside and downside
-deviations symmetrically.
+    k_2 = 0.5 * L_t^2
 
-### 3.4 Which to use for what
+- Always non-negative. Nice.
+- **Biased.** It's actually an unbiased estimate of `0.5 * E[L^2]`, which by
+  Jensen's inequality is an upper bound on `0.5 * (E[L])^2` but is *not* equal to
+  KL in general.
+- Rarely used in modern RLHF. Included here for completeness.
 
-- **Penalty in the per-token reward (shaping):** $k_1$.
-  - Pros: unbiased, simple gradient (derivative of $L_t$ w.r.t. $\log \pi_\theta$ is
-    just $1$), matches InstructGPT exactly.
-  - Cons: can go negative on a single sample, gives a noisy reward signal.
-- **Logging / diagnostics:** $k_3$.
-  - Pros: nonnegative, interpretable as "how far has the policy moved from ref".
-  - Cons: gradient is $\rho_t$ (nonlinear), complicates things if used as penalty.
+### 3.3 `k_3`: Schulman's unbiased-and-nonnegative
 
-In this repo: `kl_k1` is the shaping penalty used inside `shape_reward`; `kl_k3` is
-just for the CSV log.
+    k_3 = (rho_t - 1) - L_t
+        = exp(L_t) - 1 - L_t
+
+- Always **non-negative**, because `exp(x) - 1 - x >= 0` for all real `x` (the
+  exponential function lies above its tangent at 0). Equality only when `x = 0`.
+- **Unbiased** (with a caveat).
+- **Lower variance than `k_1`** in practice: when `k_1` has a big-magnitude
+  negative sample, `k_3` pulls it back up via the `rho - 1` term, and vice versa.
+
+A quick geometric picture: `k_1` is just the raw log-ratio of whatever token you
+happened to draw. `k_3` adds a symmetric correction penalizing any deviation of
+`rho` from 1 — both upside and downside.
+
+### 3.4 Which do we use for what?
+
+- **Penalty inside the per-token reward (shaping):** `k_1`.
+  - It's unbiased, its gradient with respect to `log pi_theta` is just `1`
+    (simple), and it matches InstructGPT exactly.
+  - Downside: single samples can be negative, so the per-token reward signal is
+    noisy. But GAE helps smooth that out.
+- **Logging and diagnostics:** `k_3`.
+  - Non-negative, so it plots as an interpretable "how far has the policy moved
+    from ref" number.
+  - Downside: its gradient is `rho`, which is nonlinear — makes it a pain if you
+    try to use it *as* the penalty.
+
+In this repo: `kl_k1` goes into `shape_reward`; `kl_k3` is computed for the CSV
+log but not used in gradients.
 
 ---
 
 ## 4. Reward shaping (Problem 4.3)
 
-Put it all together. Given a batch of rollouts:
+Putting it all together. After a rollout we have:
 
-- `rm_reward[b]` — scalar reward from the RM at the last non-pad response token.
-- `logprobs_old[b, t]` — per-token log-prob under $\pi_\theta$ at rollout time.
-- `ref_logprobs[b, t]` — per-token log-prob under $\pi_\text{ref}$.
-- `response_mask[b, t]` — 1 on real response tokens.
+- `rm_reward[b]`: the RM's scalar output at the last real response token,
+  shape `(B,)`.
+- `logprobs_old[b, t]`: per-token log-prob under `pi_theta` at rollout time,
+  shape `(B, T_resp)`.
+- `ref_logprobs[b, t]`: per-token log-prob under `pi_ref`, same shape.
+- `response_mask[b, t]`: 1 on real response tokens, 0 on padding / post-EOS.
 
-Compute:
+Compute the per-token KL:
 
-$$
-\text{KL}^{k_1}_{b, t} = \log \pi_\theta(a_{b, t} \mid s_{b, t}) - \log \pi_\text{ref}(a_{b, t} \mid s_{b, t}),
-$$
+    KL_k1[b, t] = logprobs_old[b, t] - ref_logprobs[b, t]
 
-$$
-r_{b, t} = -\beta \cdot \text{KL}^{k_1}_{b, t} \cdot m_{b, t} \; + \; r_\text{RM}[b] \cdot \mathbf{1}_{t = \text{last}(b)}.
-$$
+And the per-token reward:
 
-The $\mathbf{1}_{t = \text{last}(b)}$ is the indicator that $t$ is the last real token
-of row $b$'s response — this is where the terminal RM reward gets injected.
+    r[b, t] = -beta * KL_k1[b, t] * response_mask[b, t]
+              + rm_reward[b] * (t == last_response_token_of_row_b)
 
-### Edge cases
+The indicator `(t == last_response_token_of_row_b)` is 1 exactly once per row —
+at the last real token of that row's response. That's where the terminal RM
+reward gets injected.
 
-- If an episode finished early via `<|im_end|>`, `last(b)` is that EOS position. After
-  that, `response_mask` is 0 and so is every term in the reward.
-- If the policy hit `response_max_len` without EOSing, `last(b)` is the last position
-  (still mask = 1). The RM scores whatever got generated, including the truncation.
-- With $\beta \to 0$ the KL shaping vanishes and you get pure RM terminal reward.
-  Verify this edge case in the unit test.
+### Edge cases to verify
+
+- If a row ended early via `<|im_end|>`, that EOS position is the "last real
+  token" for that row. After that, `response_mask` is 0, so every term in the
+  reward is 0.
+- If a row hit `response_max_len` without producing `<|im_end|>`, the last real
+  token is just the final position. The RM scores whatever got generated,
+  including the truncation.
+- When `beta = 0`, the KL shaping vanishes and you should get pure terminal RM
+  reward. Make this an explicit unit test.
 
 ---
 
-## 5. Adaptive KL (optional, not required)
+## 5. Adaptive KL (optional)
 
-InstructGPT actually uses an **adaptive** $\beta$: start from a target KL budget (e.g.
-6 nats over 256 tokens), and after each PPO iteration adjust $\beta$ multiplicatively
-based on whether the measured KL exceeded or fell short of the target. We default
-to a **fixed** $\beta = 0.02$ in this repo because it's simpler and good enough for
-a teaching impl. Adaptive KL is a good 30-minute extension once everything else works.
+InstructGPT actually uses an *adaptive* `beta`: it targets a specific KL budget
+(e.g. 6 nats total over 256 tokens) and adjusts `beta` multiplicatively after each
+iteration based on whether the measured KL overshot or undershot that target.
+
+We default to a **fixed** `beta = 0.02` in this repo because it's simpler and good
+enough for a teaching implementation. Adaptive KL is a nice 30-minute extension
+once everything else is working — not required.
 
 ---
 
 ## 6. Common pitfalls
 
-- **Per-token KL computed on positions that didn't exist.** Pad positions, post-EOS
-  positions. Multiply $\text{KL}_t$ by `response_mask[b, t]` before using it as
-  reward.
-- **Ref log-probs recomputed with dropout on.** Ref is frozen — call with
-  `model.eval()` and wrap in `torch.no_grad()`. Numerical differences here propagate
-  directly into the shaping penalty and will make training noisy.
-- **$\beta$ too small.** Reward goes up, KL explodes, responses get weird — classic
-  reward hacking. Bump $\beta$.
-- **$\beta$ too large.** Reward barely moves, entropy collapses, responses look like
-  SFT with minor variations. Lower $\beta$.
+- **KL computed on positions that aren't real.** Padding, or positions after EOS,
+  contribute to the mean if you don't mask. Always multiply `KL_t` by the
+  response mask before using it.
+- **Ref log-probs recomputed with dropout on.** The reference is supposed to be
+  deterministic and frozen. If you forget to call `model.eval()` or use
+  `torch.no_grad()`, you'll get noisy ref log-probs, which feed directly into the
+  KL penalty and make training jittery.
+- **`beta` too small.** Reward climbs, KL explodes faster, responses get weird.
+  Classic reward hacking — raise `beta`.
+- **`beta` too large.** Reward barely moves, entropy collapses, responses look
+  like SFT with minor cosmetic differences. Lower `beta`.
 
 ---
 
 ## 7. What to commit to `notes/04-ppo-kl.md`
 
-After finishing Problems 4.2 and 4.3, append:
+After finishing Problems 4.2 and 4.3, add:
 
-- Your derivation that $e^x - 1 - x \ge 0$ for all $x$ (easy: convexity argument).
-- A small experiment: compute $k_1$ and $k_3$ on synthetic log-prob samples from two
-  fixed discrete distributions, compare against the true (analytically computed) KL,
-  and observe that both are unbiased but $k_1$ has more variance.
+- Your own derivation that `exp(x) - 1 - x >= 0` for all `x`. Easy one-liner from
+  convexity: `exp(x)` lies above its tangent at `x = 0`.
+- A small experiment: pick two fixed discrete distributions, compute their *exact*
+  KL analytically, then sample from one and estimate the KL using both `k_1` and
+  `k_3`. Verify that both are approximately unbiased and that `k_1` has clearly
+  higher variance. This is the cleanest way to internalize the difference.

--- a/notes/04-ppo-policy.md
+++ b/notes/04-ppo-policy.md
@@ -2,58 +2,52 @@
 
 ## Purpose
 
-Theory for Problems 4.5, 4.6, and 4.7. Derive and reason about the three terms in the
-PPO optimization objective:
+Theory packet for Problems 4.5, 4.6, and 4.7. Derive and reason about the three
+terms that make up the PPO loss:
 
-$$
-\mathcal{L}_\text{PPO}(\theta) = \mathcal{L}_\pi(\theta) + c_v \cdot \mathcal{L}_V(\theta) - c_\text{ent} \cdot H(\theta).
-$$
+    L_PPO = L_policy + c_v * L_value - c_entropy * H
 
 By the end you should be able to:
 
 1. State the PPO clipped policy loss and derive its piecewise gradient.
-2. Explain why the clipped ratio provides a "trust region" without actually solving
-   one.
-3. Derive the clipped value loss and explain why the clipping helps early in
-   training.
+2. Explain why clipping the importance ratio gives us a "trust region" without
+   actually solving a constrained optimization problem.
+3. Derive the clipped value loss and explain why the clip helps early in training.
 4. Derive the gradient of the masked entropy term.
 
 ---
 
-## 1. The setup: importance-sampled policy gradient
+## 1. Setup: importance-sampled policy gradient
 
-Recall from `04-ppo-gae.md`: the vanilla policy gradient is
+Recall from `04-ppo-gae.md` that the policy gradient with advantage baseline is:
 
-$$
-\nabla_\theta J = \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\sum_t \nabla \log \pi_\theta(a_t \mid s_t) \cdot A_t\right].
-$$
+    grad J = E_{tau ~ pi_theta} [ sum_t grad log pi_theta(a_t | s_t) * A_t ]
 
-**Problem**: to compute this gradient we need rollouts from the *current* policy
-$\pi_\theta$. If we want to reuse a batch of rollouts for multiple gradient steps (to
-amortize the cost of generation), the rollouts quickly become "off-policy" and the
-expectation is wrong.
+**The problem.** To estimate this gradient, we need trajectories from the *current*
+policy `pi_theta`. But rolling out a batch of trajectories is expensive — each
+rollout requires a full autoregressive generation. We'd really like to reuse each
+batch of rollouts for several gradient steps to amortize that cost. Once the
+policy has been updated a few times, though, the rollouts are "off-policy" and the
+expectation is no longer correct for the new policy.
 
-**Fix**: importance sampling. Rollouts come from a *snapshot* policy $\pi_\text{old}$
-(frozen at the start of each outer iteration). We rewrite the objective as
+**The fix.** Importance sampling. The rollouts come from a snapshot policy
+`pi_old`, frozen at the start of the current outer iteration. We rewrite the
+objective as an expectation under `pi_old` with an importance weight:
 
-$$
-J(\theta) = \mathbb{E}_{\tau \sim \pi_\text{old}}\!\left[\sum_t \frac{\pi_\theta(a_t \mid s_t)}{\pi_\text{old}(a_t \mid s_t)} \cdot A_t\right],
-$$
+    J(theta) = E_{tau ~ pi_old} [ sum_t rho_t(theta) * A_t ]
 
-where the importance ratio
+where the **importance ratio** is:
 
-$$
-\rho_t(\theta) = \frac{\pi_\theta(a_t \mid s_t)}{\pi_\text{old}(a_t \mid s_t)}
-= \exp\bigl(\log \pi_\theta(a_t \mid s_t) - \log \pi_\text{old}(a_t \mid s_t)\bigr)
-$$
+    rho_t(theta) = pi_theta(a_t | s_t) / pi_old(a_t | s_t)
+                 = exp( log pi_theta(a_t | s_t) - log pi_old(a_t | s_t) )
 
-accounts for the distribution shift. Under mild conditions $\nabla_\theta$ on this
-expression equals $\nabla_\theta J$, as long as $\pi_\theta \approx \pi_\text{old}$.
+As long as `pi_theta` stays close to `pi_old`, the gradient of this rewritten
+expression equals the policy gradient.
 
-**The catch**: if $\pi_\theta$ drifts far from $\pi_\text{old}$, the ratios can be
-huge and the gradient estimator blows up with variance. This is the classic failure
-of importance sampling. We need a way to reuse the batch but prevent the policy
-from moving too far in one update.
+**The catch.** If `pi_theta` drifts far from `pi_old`, the ratios `rho_t` can
+become enormous or tiny, and the gradient estimator explodes with variance. Every
+importance-sampling method has this failure mode. We need some way to keep using
+the batch while preventing the policy from moving too far per update.
 
 ---
 
@@ -61,79 +55,92 @@ from moving too far in one update.
 
 ### 2.1 Definition
 
-$$
-\mathcal{L}_t^\text{clip}(\theta) = -\min\bigl(\rho_t(\theta) \cdot A_t, \; \text{clip}(\rho_t(\theta), 1 - \varepsilon, 1 + \varepsilon) \cdot A_t\bigr),
-$$
+For each token, define two candidate surrogates:
 
-$$
-\mathcal{L}_\pi(\theta) = \frac{1}{N} \sum_{b, t} m_{b, t} \cdot \mathcal{L}^\text{clip}_{b, t}(\theta).
-$$
+    surr1 = rho * A
+    surr2 = clip(rho, 1 - epsilon, 1 + epsilon) * A
 
-where $N$ is the count of real (masked-in) response tokens in the batch and
-$\varepsilon = 0.2$ is the clip range. Per token:
+where `clip(x, lo, hi)` pins `x` to the range `[lo, hi]`. `epsilon` is typically
+0.2.
 
-- $\text{surr}_1 = \rho A$ is the importance-sampled policy gradient objective.
-- $\text{surr}_2 = \text{clip}(\rho, 1-\varepsilon, 1+\varepsilon) \cdot A$ is the same
-  with $\rho$ pinned to $[1-\varepsilon, 1+\varepsilon]$.
-- We take the **min** inside the loss — i.e. the **pessimistic** one — so the policy
-  is not rewarded for running up the ratio beyond the clip in a direction that
-  increases the objective. *But* it is still allowed to pull the ratio back toward 1
-  when that would decrease the objective.
+The PPO per-token loss is:
 
-### 2.2 What "pessimistic" means, concretely
+    L_clip_t = - min(surr1, surr2)
 
-There are four cases based on the sign of $A_t$ and whether $\rho$ is inside the clip:
+And the total policy loss:
 
-| $A_t$ sign | $\rho$ position            | $\text{surr}_1$ vs $\text{surr}_2$        | min picks | Gradient w.r.t. $\log \pi$ |
-|------------|----------------------------|-----------------------------|-----------|----------------------------|
-| $A > 0$    | $\rho \in [1-\varepsilon, 1+\varepsilon]$ | equal                | $\text{surr}_1$  | $-A \cdot \rho$            |
-| $A > 0$    | $\rho > 1 + \varepsilon$   | $\text{surr}_1$ bigger (= $\rho A$) | $\text{surr}_2$  | **zero** (clipped)         |
-| $A > 0$    | $\rho < 1 - \varepsilon$   | $\text{surr}_1$ smaller            | $\text{surr}_1$  | $-A \cdot \rho$ (not clipped)|
-| $A < 0$    | $\rho \in [1-\varepsilon, 1+\varepsilon]$ | equal                | $\text{surr}_1$  | $-A \cdot \rho$            |
-| $A < 0$    | $\rho < 1 - \varepsilon$   | $\text{surr}_1$ less negative      | $\text{surr}_2$  | **zero** (clipped)         |
-| $A < 0$    | $\rho > 1 + \varepsilon$   | $\text{surr}_1$ more negative      | $\text{surr}_1$  | $-A \cdot \rho$ (not clipped)|
+    L_policy = (1 / N) * sum over (b, t) of mask[b, t] * L_clip[b, t]
 
-The pattern: **clipping only fires when it would drag the objective back** (i.e.
-the policy is already moving in a good direction and has gone "too far"). It *does
-not* fire when the ratio is on the wrong side — in those cases the unclipped branch
-provides gradient signal back toward the clip range.
+where `N` is the count of masked-in response tokens.
 
-### 2.3 Deriving the piecewise gradient (do this by hand)
+Read the `min` carefully: we take the **smaller** (more pessimistic) of the two
+surrogates, then *negate* the whole thing for the loss. Equivalently: inside the
+objective (before the negation), we take the *minimum* of `surr1` and `surr2`,
+i.e. the less favorable one. This is the key idea — the surrogate is set up so
+that the policy cannot be rewarded for running the ratio far outside
+`[1 - eps, 1 + eps]` in the direction of increasing the objective.
 
-For the unclipped case ($\text{surr}_1$ picked), the per-token loss is
-$\ell = -\rho A$. Using $\rho = \exp(\log \pi - \log \pi_\text{old})$:
+### 2.2 What "pessimistic" means, case by case
 
-$$
-\frac{\partial \rho}{\partial \log \pi} = \rho,
-\qquad
-\frac{\partial \ell}{\partial \log \pi} = -A \cdot \rho.
-$$
+There are essentially four cases based on the sign of `A` and where `rho` sits.
+Here's a compact table. "Gradient" means gradient of `L_clip_t` with respect to
+`log pi_theta(a_t | s_t)`.
 
-Equivalently, $\partial \ell / \partial \log \pi = -A$ when $\rho = 1$ — recovering the
-vanilla policy gradient in the on-policy limit.
+| `A` sign | `rho` position | which surrogate is smaller? | `min` picks | gradient |
+|----------|----------------|------------------------------|-------------|----------|
+| A > 0 | rho inside `[1-eps, 1+eps]` | equal | either | `-A * rho` |
+| A > 0 | rho > 1 + eps | `surr2` (clipped is smaller, since `rho*A` is bigger) | `surr2` | **0** (clipped) |
+| A > 0 | rho < 1 - eps | `surr1` (unclipped is smaller) | `surr1` | `-A * rho` |
+| A < 0 | rho inside `[1-eps, 1+eps]` | equal | either | `-A * rho` |
+| A < 0 | rho < 1 - eps | `surr2` | `surr2` | **0** (clipped) |
+| A < 0 | rho > 1 + eps | `surr1` | `surr1` | `-A * rho` |
 
-For the clipped case ($\text{surr}_2$ picked *and* it doesn't depend on $\theta$ in
-that regime — i.e. the clip is saturated): the argument of the clip has no gradient,
-so $\partial / \partial \log \pi = 0$. The token's gradient contribution is literally
-zero.
+The pattern: **the clip only fires when firing it would pull the objective back**.
+That is, when the policy is already moving in a good direction and has gone "too
+far". When the policy is moving in the wrong direction (ratio on the wrong side
+of 1), the clip *doesn't* fire, so we still get gradient signal pushing the ratio
+back toward 1.
 
-You verify this with an **edge test** in Problem 4.5: set all ratios to a large value
-($\rho = 5$, say) and $A > 0$. Every token should be in the "$A > 0$, $\rho > 1+\varepsilon$,
-clip picks $\text{surr}_2$" regime. Autograd must report exactly zero gradient on those
-tokens. If it reports nonzero, your implementation is using `max` instead of `min`
-or has a sign error.
+### 2.3 Deriving the piecewise gradient
 
-### 2.4 Why this works as a trust region substitute
+For the unclipped case, the per-token loss is `L = -rho * A`. Using
+`rho = exp(log pi_theta - log pi_old)`:
 
-The "clip fraction" (fraction of tokens where the clip fires) is typically 10–30% of
-tokens per iteration. When the clip fires, that token contributes zero signal to the
-update, so the effective gradient magnitude decreases as $\theta$ drifts farther from
-$\theta_\text{old}$. This acts like a soft trust region: small updates move freely,
-large updates get throttled automatically.
+    d rho / d log pi_theta = rho
 
-Contrast with TRPO (the predecessor), which solves a constrained optimization at every
-step with a conjugate-gradient solver — PPO gets comparable performance with a simple
-`min(surr1, surr2)` and a standard optimizer. That's why everyone uses PPO.
+So:
+
+    d L / d log pi_theta = -A * rho
+
+At `rho = 1` (on-policy limit), this simplifies to `-A`, which recovers the
+vanilla policy gradient direction.
+
+For the clipped case, `surr2 = (a constant with respect to theta) * A`. The
+clip saturates, so changing `log pi_theta` doesn't change `surr2`. Therefore:
+
+    d L / d log pi_theta = 0
+
+That token contributes zero signal to this gradient step.
+
+Verify this with an **edge test** in Problem 4.5. Set every ratio to a large
+value (say `rho = 5`) and `A > 0`. Every token should land in the "A > 0,
+rho > 1 + eps, clip active" regime. Autograd must report exactly zero gradient on
+those tokens. If any token has a nonzero gradient, you've got a `max` instead of
+`min`, or a sign error somewhere.
+
+### 2.4 Why this works as a trust region
+
+In practice, on a given update, some fraction of tokens hit the clip — this is
+the **clip fraction**, typically 10–30% in a healthy run. Clipped tokens
+contribute zero to the gradient, so the effective magnitude of the update
+*decreases* as `pi_theta` drifts further from `pi_old`. That gives us a soft
+self-regulating trust region: small updates move freely, large ones get throttled
+automatically.
+
+Contrast with TRPO, PPO's predecessor: TRPO solves a hard constrained
+optimization at every step with conjugate-gradient. PPO gets comparable
+performance with `min(surr1, surr2)` and a standard optimizer. That simplicity is
+why everyone uses PPO.
 
 ---
 
@@ -141,58 +148,66 @@ step with a conjugate-gradient solver — PPO gets comparable performance with a
 
 ### 3.1 Unclipped form
 
-The value head's job is to regress onto the GAE return $R_t = A_t + V_t^\text{old}$
-(which we computed at rollout time and treat as a constant):
+The value head's job is to regress toward the GAE return:
 
-$$
-\mathcal{L}_V^\text{unclipped}(\theta) = \frac{1}{2} \sum_{b, t} m_{b, t} \bigl(V_\theta(s_{b, t}) - R_{b, t}\bigr)^2 \Big/ N.
-$$
+    R_t = A_t + V_old(s_t)
 
-Straightforward MSE; gradient is $m \cdot (V - R) \cdot \partial V/\partial \theta$.
+which is computed at rollout time and treated as a constant during optimization
+(stop-gradient). The simplest value loss is plain MSE:
+
+    L_V_unclipped = (1 / (2*N)) * sum over (b, t) of mask[b, t] * (V_theta(s_t) - R_t)^2
+
+Gradient is `mask * (V_theta - R) * dV_theta/dtheta` — standard MSE.
 
 ### 3.2 Clipped form
 
-$$
-V_\theta^\text{clipped}(s_t) = V^\text{old}_t + \text{clip}\bigl(V_\theta(s_t) - V^\text{old}_t,\; -\varepsilon_v,\; +\varepsilon_v\bigr),
-$$
+The clipped value loss mirrors the policy clip. Define:
 
-$$
-\mathcal{L}_V(\theta) = \frac{1}{2} \sum_{b, t} m_{b, t} \cdot \max\!\bigl((V_\theta - R)^2,\; (V_\theta^\text{clipped} - R)^2\bigr) \Big/ N.
-$$
+    V_clipped(s_t) = V_old(s_t) + clip(V_theta(s_t) - V_old(s_t), -eps_v, +eps_v)
 
-Same "pessimistic" idea as the policy clip: whichever of $V_\theta$ or $V_\theta^\text{clipped}$
-is **farther** from the target $R$ determines the squared error. Why **max** (not
-min) here? Because squared error is a loss we want to *minimize*, and we want to
-pessimistically compute how bad the prediction is — i.e. use the larger of the two
-squared errors. That prevents $V_\theta$ from jumping too far in one update.
+Then:
 
-### 3.3 Why clip the value
+    per_tok_loss = 0.5 * max( (V_theta - R)^2, (V_clipped - R)^2 )
+    L_V = (1 / N) * sum over (b, t) of mask[b, t] * per_tok_loss[b, t]
 
-Early in PPO training, the policy is barely changing while the value head is
-catching up fast. Without clipping, the value can overshoot — predicting $V$ values
-that don't match the scale of future returns — and this wrecks the advantage
-estimates used by the policy loss (since the TD errors $\delta_t$ become garbage).
-Clipping $V$ per-update keeps the value estimate close to its own previous estimate,
-so advantages stay on a stable scale for the policy to consume.
+Same idea as the policy clip: the value can only move at most `eps_v` away from
+its snapshot value `V_old` per update. Why **max** here (instead of `min` in the
+policy case)? Because squared error is a loss we want to *minimize*, and we want
+to pessimistically pick the larger squared error — i.e. the worse of the two
+predictions — as our training loss. That keeps `V_theta` from jumping too far in
+any single update.
 
-In the on-policy limit ($V_\theta = V^\text{old}$), both branches give the same value
-and the clip has no effect. As $V_\theta$ drifts, the clip kicks in.
+### 3.3 Why clip the value at all
 
-### 3.4 Gradient
+Early in PPO training, the policy is barely moving while the value head is
+learning fast from scratch. Without clipping, the value head can overshoot —
+predicting return values that don't match the scale of actual future returns —
+and this wrecks the advantage estimates, since the TD errors `delta_t` become
+garbage. Then the policy loss feeds on garbage advantages and everything
+destabilizes.
 
-The gradient is piecewise linear in $V_\theta$:
+Clipping `V_theta` to stay within `eps_v` of its previous value keeps advantages
+on a stable scale across updates, at the cost of slower value learning.
 
-- Where $|V_\theta - V^\text{old}| \le \varepsilon_v$: the clip is inactive, and
-  $(V_\theta - R)^2$ and $(V_\theta^\text{clipped} - R)^2$ are equal. Gradient =
-  $m \cdot (V_\theta - R)$.
-- Where the clip is active: the clipped branch's gradient through
-  $V_\theta$ is zero (it was clipped). If the unclipped branch has the larger squared
-  error (max picks it), gradient = $m \cdot (V_\theta - R)$. Otherwise the max picks
-  the clipped branch, whose gradient w.r.t. $\theta$ is zero — no signal.
+In the on-policy limit (when `V_theta = V_old`), both branches of the max are
+equal and the clip has no effect. As `V_theta` drifts, the clip kicks in.
 
-The test in Problem 4.6: gradient-check the whole thing at fp64, and add a case where
-$V_\theta$ is far from $V^\text{old}$ and far from $R$ — check the gradient equals what
-you'd compute for the selected branch.
+### 3.4 Gradient of the clipped value loss
+
+Piecewise linear in `V_theta`:
+
+- Where `|V_theta - V_old| <= eps_v`: the clip is inactive,
+  `V_clipped = V_theta`, and the two branches of the max are equal. The gradient
+  is `mask * (V_theta - R)`.
+- Where the clip is active:
+  - The clipped branch `(V_clipped - R)^2` has no gradient through `V_theta`
+    (because `V_clipped` is pinned).
+  - The unclipped branch `(V_theta - R)^2` has the usual gradient.
+  - Whichever branch gets picked by `max` determines the gradient.
+
+Gradient-check the whole thing at fp64 in Problem 4.6. Include a case where
+`V_theta` is far from both `V_old` and `R` — make sure the gradient matches what
+you'd compute by hand for the selected branch.
 
 ---
 
@@ -200,102 +215,99 @@ you'd compute for the selected branch.
 
 ### 4.1 Purpose
 
-Adding an entropy term to the loss with negative sign
+Add the negated entropy of the policy to the loss:
 
-$$
--c_\text{ent} \cdot H(\pi_\theta) = -c_\text{ent} \cdot \mathbb{E}\!\left[-\sum_v \pi_\theta(v \mid s) \log \pi_\theta(v \mid s)\right]
-$$
+    L_total = L_policy + c_v * L_value - c_entropy * H(pi_theta)
 
-rewards policies that keep distributional "width". This prevents premature mode
-collapse — where the policy becomes deterministic (always picks the argmax) too
-early and stops exploring.
+The negative sign means a gradient step *increases* entropy — rewarding the policy
+for keeping its per-token distributions broad. This prevents **premature mode
+collapse**, where the policy becomes almost deterministic (always picks the
+argmax) early on and stops exploring alternatives.
 
-In our config: `entropy_coef = 0.0` by default. Start without; add a small amount
-(`0.01`) if you see the policy go deterministic within a few iterations (entropy
-dropping near zero, generations becoming repetitive).
+In our config, `c_entropy = 0.0` by default — we start without an entropy bonus.
+If you see the policy go deterministic within a few iterations (entropy dropping
+near zero, generations getting repetitive), bump it to `0.01`.
 
-### 4.2 Masked entropy over response tokens
+### 4.2 Masked entropy
 
-$$
-H(\pi_\theta) = \frac{1}{N} \sum_{b, t} m_{b, t} \cdot H\bigl(\pi_\theta(\cdot \mid s_{b, t})\bigr),
-$$
+For one position, the entropy of the per-token distribution `p` over the vocab is:
 
-where per-token entropy is
+    H(p) = - sum over v of p[v] * log p[v]
 
-$$
-H_t = -\sum_{v=1}^{V} \pi_\theta(v \mid s_t) \log \pi_\theta(v \mid s_t).
-$$
+For a batch of positions:
 
-### 4.3 Gradient of $H$ with respect to logits (derive this)
+    H_batch = (1 / N) * sum over (b, t) of mask[b, t] * H(p[b, t])
 
-Let $z \in \mathbb{R}^V$ be logits, $p = \text{softmax}(z)$. Using
-$\partial p_v / \partial z_u = p_v(\delta_{v, u} - p_u)$ from the SFT note:
+### 4.3 Gradient of `H` with respect to logits
 
-$$
-\frac{\partial H}{\partial z_u}
-= -\sum_v \frac{\partial p_v}{\partial z_u} (\log p_v + 1)
-= -\sum_v p_v(\delta_{v, u} - p_u)(\log p_v + 1).
-$$
+Let `z` be the logits and `p = softmax(z)`. Using the softmax derivative
+`d p[v] / d z[u] = p[v] * (delta(v, u) - p[u])` from `02-sft.md`:
 
-Expand the two terms in the parenthesis and simplify:
+    d H / d z[u]
+    = - sum over v of (d p[v] / d z[u]) * (log p[v] + 1)
+    = - sum over v of p[v] * (delta(v, u) - p[u]) * (log p[v] + 1)
 
-$$
-\frac{\partial H}{\partial z_u} = -p_u(\log p_u + 1) + p_u \sum_v p_v(\log p_v + 1)
-= -p_u \log p_u - p_u + p_u(- H + 1)
-= -p_u (\log p_u + H).
-$$
+Expand:
 
-So in vector form:
+    = - p[u] * (log p[u] + 1)  +  p[u] * sum over v of p[v] * (log p[v] + 1)
 
-$$
-\boxed{\; \frac{\partial H}{\partial z} = -\, p \odot \bigl(\log p + H\bigr). \;}
-$$
+The sum on the right equals `-H + 1`, since `sum_v p[v] * log p[v] = -H` and
+`sum_v p[v] = 1`. So:
+
+    d H / d z[u]
+    = - p[u] * (log p[u] + 1)  +  p[u] * (-H + 1)
+    = - p[u] * (log p[u] + H)
+
+In vector form:
+
+    d H / d z  =  - p * (log p + H)
+
+(elementwise product).
 
 ### 4.4 Sanity check
 
-At the uniform distribution $p_v = 1/V$: $\log p_v = -\log V$, $H = \log V$, and
-$\log p_v + H = -\log V + \log V = 0$. So $\partial H/\partial z = 0$ — entropy is
-stationary (maximized) at uniform. Good.
-
-At a near-deterministic $p$ (most mass on one class): $\log p_v$ is very negative for
-all but one $v$, and the gradient is highly nonzero in a direction that smooths the
-distribution. Also good.
+- **Uniform distribution** (`p[v] = 1/V` for all `v`): `log p[v] = -log V`,
+  `H = log V`, so `log p + H = 0`. The gradient is zero everywhere, meaning
+  entropy is stationary. Good — uniform is the maximum-entropy distribution, and
+  we'd expect zero gradient at the maximum.
+- **Near-deterministic** distribution: for the wrong classes, `log p[v]` is very
+  negative and the gradient is highly nonzero, pointing in a direction that
+  smooths the distribution back out. Good.
 
 ### 4.5 Test
 
-Gradient-check at fp64 on a small logits tensor. Apply the mask, verify that flipping
-logits outside the mask doesn't change the entropy value or its gradient.
+Gradient-check the entropy at fp64 on a small logits tensor. Apply the mask,
+verify that flipping logits *outside* the mask doesn't change the computed
+entropy or its gradient.
 
 ---
 
 ## 5. The full PPO loss
 
-Putting the three pieces together:
+Combine the three pieces:
 
-$$
-\mathcal{L}_\text{PPO} = \mathcal{L}_\pi + c_v \cdot \mathcal{L}_V - c_\text{ent} \cdot H.
-$$
+    L_PPO = L_policy + c_v * L_value - c_entropy * H
 
 Typical coefficients (our config):
 
-- $c_v = 0.5$: value loss has half the weight of policy loss.
-- $c_\text{ent} = 0.0$ (start), up to $0.01$ if needed.
-- $\varepsilon = 0.2$ for the policy ratio clip.
-- $\varepsilon_v = 0.2$ for the value clip.
+- `c_v = 0.5`: value loss has half the weight of the policy loss.
+- `c_entropy = 0.0` to start; raise to `0.01` if entropy collapses.
+- `epsilon = 0.2` for the policy ratio clip.
+- `epsilon_v = 0.2` for the value clip.
 
-Backward through the sum, clip gradients to norm 1.0, step the optimizer. Four epochs
-over the rollout batch (Problem 5.3) before throwing away the rollout and starting the
-next outer iteration.
+Backward through the sum, clip the gradient norm at 1.0, step the optimizer. Four
+epochs over the rollout batch (Problem 5.3) before you throw away the rollout and
+start the next outer iteration.
 
 ---
 
 ## 6. What to commit to `notes/04-ppo-policy.md`
 
-After finishing Problems 4.5, 4.6, 4.7, append:
+After Problems 4.5, 4.6, 4.7, add:
 
-- Your derivation of the clipped-surrogate piecewise gradient (the table in §2.2,
-  but with the algebra filled in).
-- Your derivation of the entropy gradient (redo §4.3 on paper).
-- The numerical result of your edge test: "with all ratios at 5 and A > 0, every
-  masked token's gradient is 0.0".
-- A note on what coefficients you tried and what happened.
+- Your own derivation of the clipped-surrogate piecewise gradient (the table in
+  §2.2, but with the algebra written out).
+- Your own derivation of the entropy gradient (section 4.3 redone by hand).
+- The numerical result of your edge test: "with every ratio set to 5 and A > 0,
+  each masked token's gradient was exactly 0.0".
+- A note on what coefficients you tried and what you saw happen.

--- a/notes/05-ppo.md
+++ b/notes/05-ppo.md
@@ -2,101 +2,99 @@
 
 ## Purpose
 
-Theory and engineering notes for Module 5 (Problems 5.1 through 5.5). The math was in
-the `04-*.md` files. Here we zoom out and talk about:
+Theory and engineering notes for Module 5 (Problems 5.1 through 5.5). The math is
+all in `04-*.md`. This note zooms out and talks about:
 
-1. The four models you need in memory and how to fit them on a 24GB GPU.
+1. The four models you need in memory simultaneously, and how to fit them on a
+   24GB GPU.
 2. The outer/inner loop structure of a PPO iteration.
-3. What signals to log and what their healthy trajectories look like.
-4. How to scale the model-size knob so the same codebase runs for
-   `gpt2-small|medium|large|xl` even if the larger ones OOM.
+3. What to log and what a healthy training run should look like.
+4. How to make the code work for all four GPT-2 sizes, even if the larger ones
+   OOM.
 
 ---
 
 ## 1. The four models
 
-During PPO you have *four* GPT-2s instantiated simultaneously:
+During PPO you have *four* GPT-2s alive at the same time:
 
 | Name      | Params | Trainable? | Gradients? | Optimizer state? | Role                                 |
 |-----------|--------|------------|------------|------------------|--------------------------------------|
-| Policy    | 124M   | yes        | yes        | yes (AdamW m, v) | Samples actions; updated by PPO.     |
-| Value     | shared backbone + 1 linear head | yes | yes | yes | Outputs $V(s_t)$ per position.       |
-| Reference | 124M   | **no**     | no         | no               | $\pi_\text{ref}$ — KL penalty anchor.|
-| Reward    | 124M   | **no**     | no         | no               | Terminal reward at end of response.  |
+| Policy    | 124M   | yes        | yes        | yes (AdamW m, v) | Samples tokens; updated by PPO.      |
+| Value     | shared backbone + 1 linear head | yes | yes | yes | Outputs `V(s_t)` per position.       |
+| Reference | 124M   | **no**     | no         | no               | `pi_ref` — anchors the KL penalty.   |
+| Reward    | 124M   | **no**     | no         | no               | Scores the response at the end.      |
 
-The policy and the value model **share the transformer backbone**. This is a design
-choice (documented in Problem 5.1). Alternative: separate networks. Pros and cons:
+The policy and value **share a transformer backbone** by default. This is a design
+choice and there's a real alternative:
 
-- **Shared backbone** (our default): half the memory for the trainable models. Value
-  and policy gradients interact in the backbone, which usually helps (the value
-  signal provides an auxiliary task); can occasionally hurt if one head's gradient
-  dominates. Implement by having a single `GPT` module with two heads: `lm_head`
-  (for policy logits, tied to `wte`) and `value_head` (a `nn.Linear(n_embd, 1)`).
-- **Separate networks**: more stable, 2x the trainable memory. Used in some OpenAI
-  recipes.
+- **Shared backbone** (our default): half the trainable memory. Value and policy
+  gradients both flow through the backbone, which usually helps (the value loss
+  provides a useful auxiliary task). Occasionally hurts if one of the two
+  gradients dominates. Implementation: a single `GPT` module with two heads —
+  `lm_head` (tied to `wte`, produces policy logits) and `value_head` (a
+  `nn.Linear(n_embd, 1)`).
+- **Separate networks**: more stable, but 2x the trainable memory and optimizer
+  state. Some OpenAI recipes use this.
 
-For 24GB we use **shared**. If you scale up to `gpt2-medium` and training is unstable,
-splitting the value head off is a one-line experiment.
+For 24GB we use shared. If you scale up to `gpt2-medium` and training feels
+unstable, splitting off the value head is a one-line experiment worth trying.
 
 ### 1.1 Weight initialization
 
-- Policy: from `sft.pt`.
-- Reference: also from `sft.pt` (exact copy, frozen). `reference_model.eval()`, all
-  params `.requires_grad_(False)`.
-- Reward model: from `rm.pt` (has the scalar head already trained).
-- Value head: **init the linear head weights to zero**, bias to zero. This makes
-  $V_0 \equiv 0$ at the start — advantages equal returns, and the value head starts
-  fresh without interfering with early policy updates. Common PPO folklore.
+- **Policy**: load from `sft.pt`.
+- **Reference**: load from `sft.pt` too (exact copy, then frozen).
+  `ref_model.eval()` and set all params to `requires_grad_(False)`.
+- **Reward model**: load from `rm.pt` (it already has its trained scalar head).
+- **Value head**: zero-init the linear weights and bias. This makes
+  `V_0(s) ≡ 0` at the start. Advantages equal returns initially, and the value
+  head gets to learn fresh without corrupting early policy updates. Common
+  folklore in PPO implementations.
 
 ---
 
 ## 2. Memory budget (Problem 5.1)
 
-Bf16 mixed precision throughout. Fp32 master weights + AdamW state on *trainable*
-params only. Activations checkpointed.
+We use bf16 mixed precision throughout. Fp32 master weights and AdamW state are
+stored only for trainable parameters. Activations are gradient-checkpointed.
 
 ### 2.1 Rough count for gpt2-small
 
-- Weights (bf16, 2 bytes/param): $4 \times 124\text{M} \times 2\text{B} = 0.99$ GB
-- Fp32 master copy of trainable (policy + value backbone, but they share): ~0.5 GB
-- AdamW state (m, v in fp32): 2 $\times$ 0.5 GB = 1.0 GB
-- Activations with gradient checkpointing (batch 4 × seq 512 × 2 trainable models
-  forward): ~3–6 GB depending on checkpoint strategy
-- Rollout buffers: `logprobs_old`, `values_old`, `ref_logprobs`, `advantages`,
-  `returns`, `response_mask` — all $(B_\text{rollout}, T_\text{response})$ floats.
-  $64 \times 256 \times 4\text{B} \times 6 \approx 0.4$ GB.
-- CUDA workspace + overhead: ~1–2 GB.
+- Weights, bf16 (2 bytes per param), 4 models: `4 * 124M * 2B ≈ 0.99 GB`.
+- Fp32 master copy of trainable weights (policy + value head; backbone shared):
+  `~0.5 GB`.
+- AdamW first and second moments, both fp32: `2 * 0.5 GB = 1.0 GB`.
+- Activations with gradient checkpointing (batch 4, seq 512, 2 trainable models
+  forward): `~3–6 GB` depending on checkpoint strategy.
+- Rollout buffers (`logprobs_old`, `values_old`, `ref_logprobs`, `advantages`,
+  `returns`, `response_mask`, etc.), each `(B_rollout, T_response)` floats:
+  `64 * 256 * 4B * 6 ≈ 0.4 GB`.
+- CUDA workspace and general overhead: `1–2 GB`.
 
-**Total**: ~7–10 GB. Plenty of headroom on a 24GB card.
+**Total: roughly 7–10 GB.** Plenty of headroom on a 24GB card.
 
 ### 2.2 gpt2-medium (355M) is tight
 
-Weights scale linearly (roughly 3x), as does optimizer state. You'll need:
+Weights and optimizer state both scale roughly linearly, so medium is about 3x
+larger. You'll need:
 
-- Smaller `rollout_batch_size` (16 instead of 64).
-- Maybe smaller `response_max_len` (128 instead of 256).
-- Definitely gradient checkpointing on.
+- Smaller `rollout_batch_size` (try 16 instead of 64).
+- Possibly smaller `response_max_len` (128 instead of 256).
+- Gradient checkpointing definitely on.
 
 ### 2.3 Memory check script (Problem 5.1)
 
-```
-python -c "
-import torch
-from config import GPTConfig
-from model import GPT
-cfg = GPTConfig()  # gpt2-small defaults
-# instantiate 4 models, one dummy forward, print torch.cuda.max_memory_allocated()
-"
-```
-
-Write the output into this note file for each size that fits.
+Write a small script that instantiates all four models, runs one dummy forward,
+and prints `torch.cuda.max_memory_allocated()`. Log the output into this note
+for every size that fits.
 
 ---
 
 ## 3. The outer loop (Problem 5.2)
 
-One PPO iteration has two phases: **rollout** (no-grad, generate data) and **optimize**
-(K epochs over that data). Pseudocode:
+One PPO iteration has two phases: a **rollout** phase (no gradients, generate
+data) and an **optimize** phase (K epochs of gradient steps on that data).
+Pseudocode:
 
 ```
 for iter in range(num_iters):
@@ -107,7 +105,7 @@ for iter in range(num_iters):
         response_ids, logprobs_old, values_old, mask = \
             generate_with_logprobs(policy, value_head, prompts)
         ref_logprobs = gather_logprobs(ref_model(prompts + response_ids), response_ids)
-        rm_rewards   = reward_model(prompts + response_ids)  # scalar per row
+        rm_rewards   = reward_model(prompts + response_ids)  # one scalar per row
         kl_t         = logprobs_old - ref_logprobs
         per_tok_r    = shape_reward(rm_rewards, kl_t, mask, kl_coef)
         advantages, returns = gae(per_tok_r, values_old, mask, gamma, lam)
@@ -123,7 +121,7 @@ for iter in range(num_iters):
         "mask": mask,
     }
 
-    # --- OPTIMIZE PHASE (grad on policy/value backbone) ---
+    # --- OPTIMIZE PHASE (grads on policy and value backbone) ---
     for epoch in range(K):
         for mb in minibatches(rollout):
             logits_new, values_new = policy_and_value(mb.prompts + mb.response_ids)
@@ -140,14 +138,14 @@ for iter in range(num_iters):
     log_stats(iter, ...)
 ```
 
-Key invariants:
+Three invariants to keep straight:
 
-- **`logprobs_old` is *frozen* at rollout time** and never recomputed across the inner
-  epochs. It's the reference point for the importance ratio $\rho_t$.
-- **`logprobs_new` is *recomputed* fresh in every minibatch** — that's where the
-  policy gradient flows through.
-- **All advantages/returns are stop-gradient.** Detach everything coming out of the
-  rollout before putting it into `rollout`.
+- **`logprobs_old` is *frozen* at rollout time** and never recomputed during the
+  inner epochs. It's the reference point for the importance ratio `rho_t`.
+- **`logprobs_new` is *recomputed fresh* in every minibatch** — that's where the
+  policy gradient actually flows through.
+- **All advantages and returns are stop-gradient.** Detach everything coming out
+  of the rollout before storing it.
 
 ---
 
@@ -155,64 +153,66 @@ Key invariants:
 
 ### 4.1 Minibatch sampling
 
-Shuffle a permutation of rollout indices per epoch; iterate in chunks of
-`minibatch_size`. Each minibatch spans all batch rows and all time steps — the
-"batch dim" for the inner loop is `(rollout_batch_size * T_response)` flattened.
+Shuffle a permutation of rollout indices at the start of each epoch, then iterate
+in chunks of `minibatch_size`. Each minibatch covers all batch rows and all time
+steps — the "effective batch dim" for the inner loop is essentially
+`(rollout_batch_size * T_response)` flattened.
 
-Alternative: slice by row (whole sequences together). Either works; row-wise is
-simpler for masking.
+A simpler alternative is to slice by row (whole sequences stay together). Either
+works; row-wise is slightly easier to get the masking right.
 
 ### 4.2 K epochs
 
-$K = 4$ is standard. More epochs mean more reuse of each rollout (less generation
-cost, more compute) but also more policy drift from $\pi_\text{old}$, which the clip
-handles but not indefinitely. If you see "clip fraction" (fraction of tokens where
-the min-clip fires) above 40%, lower $K$.
+`K = 4` is the standard choice. More epochs amortize rollout cost better (less
+generation per step of compute), but also let the policy drift further from
+`pi_old`. The clip handles some of that drift, but not indefinitely. If you see
+clip fraction above 40%, lower `K`.
 
 ### 4.3 Gradient flow
 
-- Policy gradient enters via `logprobs_new` in `L_pi`.
-- Value gradient enters via `values_new` in `L_v`.
-- Entropy gradient enters via `logits_new` in `H`.
-- All three backprop through the shared backbone. There is no separate step for value
-  and policy.
+- **Policy gradient** enters via `logprobs_new` inside `L_policy`.
+- **Value gradient** enters via `values_new` inside `L_value`.
+- **Entropy gradient** enters via `logits_new` inside `H`.
+- All three backpropagate through the shared backbone in one backward pass. You
+  do **not** step the policy and the value head separately.
 
 ---
 
 ## 5. Logging (Problem 5.4)
 
-Log at least these per iteration. A CSV with one row per outer iteration is enough;
-emit matplotlib plots every 50 iters.
+Log at least these per outer iteration. A CSV with one row per iteration is
+enough; emit matplotlib plots every 50 iterations so you can eyeball trajectories.
 
-| Metric             | Expected trajectory                                        |
-|--------------------|------------------------------------------------------------|
-| `mean_rm_reward`   | Trends up slowly.                                          |
-| `mean_kl_k3`       | Trends up slowly from ~0 toward a small positive (~1–6 nats over the response). If it explodes, raise $\beta$ or lower lr. |
-| `L_pi`             | Bounces around zero; should not blow up or stall at zero.  |
-| `L_v`              | Decreases over time as the value head learns.              |
-| `entropy`          | Drops slowly from the SFT entropy baseline.                |
-| `clip_fraction`    | Rises from 0 toward 10–30%. >40% means bigger updates than PPO can handle; lower $K$ or lr. |
-| `grad_norm`        | Stable at O(1) after clipping. Pre-clip norm may spike.    |
-| `tokens_per_sec`   | Roughly constant; drops signal memory pressure.            |
-| `response_length`  | Watch for creeping growth (length bias in the RM).         |
+| Metric             | Expected trajectory                                                      |
+|--------------------|--------------------------------------------------------------------------|
+| `mean_rm_reward`   | Trends up slowly.                                                        |
+| `mean_kl_k3`       | Starts near 0, drifts up to a small positive value (~1–6 nats per response). If it explodes, raise `beta` or lower the policy lr. |
+| `L_pi`             | Bounces around zero. Should not blow up or pin at zero.                  |
+| `L_v`              | Decreases over time as the value head learns.                            |
+| `entropy`          | Drifts down slowly from the SFT-level entropy.                           |
+| `clip_fraction`    | Rises from 0 into the 10–30% range. Above 40% means updates are too aggressive — lower `K` or lr. |
+| `grad_norm`        | Pre-clip may spike. Post-clip, should sit around O(1). Stable is healthy. |
+| `tokens_per_sec`   | Roughly constant. Drops signal memory pressure or disk/IO issues.         |
+| `response_length`  | Watch for a slow creep upward — that's length bias in the RM showing up. |
 
 ### 5.1 Healthy pattern
 
-Reward up, KL up slowly, entropy drifting down slowly, clip fraction ~20%, grad
-norm stable, tokens/sec stable.
+Reward climbs, KL climbs slowly, entropy drifts down slowly, clip fraction sits
+around 20%, grad norm stable, tokens/sec stable.
 
-### 5.2 Unhealthy patterns and remedies
+### 5.2 Unhealthy patterns and fixes
 
-- **Reward up, KL also way up, responses look weird.** Reward hacking. Raise $\beta$
-  (the KL coefficient) or lower policy lr. Also check the RM histograms — is there a
-  correlation with response length?
-- **Reward flat, KL flat.** Policy isn't moving. Lower $\beta$; raise lr.
-- **Clip fraction > 50%.** Updates too aggressive for PPO's clip to absorb. Lower
-  $K$, lower lr, or smaller minibatches.
-- **Entropy crashes toward zero in the first 50 iters.** Premature determinism. Set
-  $c_\text{ent} = 0.01$.
-- **Grad norm exploding.** Lower lr; check the value loss — usually it's the
-  value head overshooting. Make sure value clip $\varepsilon_v$ is on and correct.
+- **Reward up, KL also up fast, responses look weird.** Reward hacking. Raise
+  `beta` or lower the policy lr. Also look at the RM — is reward strongly
+  correlated with response length? Might be a length-bias problem in the RM.
+- **Reward flat, KL flat.** Policy isn't moving at all. Lower `beta`, raise lr.
+- **Clip fraction above 50%.** Updates too big for PPO's clip to absorb. Lower
+  `K`, lower lr, or smaller minibatches.
+- **Entropy crashes toward 0 in the first 50 iterations.** Premature determinism.
+  Set `c_entropy = 0.01`.
+- **Grad norm exploding.** Lower lr. Check the value loss in particular — usually
+  it's the value head overshooting. Make sure the value clip `eps_v` is on and
+  working correctly.
 
 ---
 
@@ -231,23 +231,23 @@ def from_name(cls, name: str) -> "GPTConfig":
     }[name]
 ```
 
-Smoke test: for each size, instantiate, do one forward + backward at `batch=1,
-seq=64`, record `torch.cuda.max_memory_allocated()`. `gpt2-small` and `gpt2-medium`
-should step cleanly on a 24GB card; `gpt2-large` and `gpt2-xl` may OOM, which is fine
-— the requirement is only that the code compiles and the forward shapes are right,
-not that it actually trains at scale.
+Smoke test: for each size, instantiate the model, run one forward + backward at
+`batch=1, seq=64`, record `torch.cuda.max_memory_allocated()`. `gpt2-small` and
+`gpt2-medium` should step cleanly on a 24GB card. `gpt2-large` and `gpt2-xl` may
+OOM, which is fine — the requirement is just that the code compiles and the
+forward shapes are correct, not that it trains at full scale.
 
-Write the memory table into this file.
+Log the memory table into this note.
 
 ---
 
 ## 7. What to commit to `notes/05-ppo.md`
 
-After finishing Module 5, append:
+After Module 5, add:
 
-- Memory printout table for each size that fits.
-- One training run's CSV (head and tail at least), or plots of reward / KL / entropy
-  / clip fraction over iterations.
-- One paragraph on instabilities you saw and how you fixed them.
-- A sanity check: compare a greedy generation from `rlhf.pt` and from `sft.pt` on
-  3 prompts. RLHF should be recognizably different (ideally better).
+- Memory printout table for each GPT-2 size that fits.
+- One training run's CSV (head and tail rows at least), or plots of
+  reward / KL / entropy / clip fraction over iterations.
+- One paragraph on any instability you saw and how you fixed it.
+- A sanity-check comparison: greedy generations from `rlhf.pt` versus `sft.pt`
+  on 3 held-out prompts. RLHF should be recognizably different, ideally better.

--- a/notes/06-eval.md
+++ b/notes/06-eval.md
@@ -2,12 +2,12 @@
 
 ## Purpose
 
-Methodology for Module 6 (Problems 6.1 through 6.3). There is very little math left at
-this stage — the theory is all behind you. This note is about:
+Methodology for Module 6 (Problems 6.1 through 6.3). There is almost no math left
+at this stage — the theory is all behind you. This note is about:
 
-1. How to compare three models fairly (base vs SFT vs RLHF).
+1. How to fairly compare three models (base vs SFT vs RLHF).
 2. How to compute a win-rate from blinded pairwise annotations.
-3. What to write in the retrospective.
+3. What to write in your retrospective.
 
 Fill this file in with your actual outputs as you run the problems.
 
@@ -15,29 +15,32 @@ Fill this file in with your actual outputs as you run the problems.
 
 ## 1. Generation comparison (Problem 6.1)
 
-Build a table with one row per held-out prompt (target: 20 prompts) and one column per
-model (base, SFT, RLHF). Each cell contains the generated response, trimmed to the
-first `<|im_end|>` or a reasonable cutoff.
+Build a table with one row per held-out prompt (target: 20 prompts) and one
+column per model (base, SFT, RLHF). Each cell holds the generated response,
+trimmed to the first `<|im_end|>` or to a reasonable cutoff if the model never
+stops.
 
 ### 1.1 Prompt selection
 
-Pick 20 prompts from the HH test split that were **not** seen in SFT or PPO training.
-A good mix:
+Pick 20 prompts from the HH test split that were **not** used in SFT or PPO
+training. A reasonable mix:
 
 - 5 helpful requests ("write me a Python function that ...").
-- 5 conversational turns ("I've been feeling stressed about ...").
+- 5 conversational openers ("I've been feeling stressed about ...").
 - 5 factual questions ("What's the capital of Kenya?").
-- 5 edge cases where base GPT-2 is known to fail (long multi-step instructions,
-  requests for specific formats, requests for lists).
+- 5 edge cases where base GPT-2 is known to fail: long multi-step instructions,
+  requests for specific formats (like JSON or tables), requests for lists.
 
 ### 1.2 Generation settings
 
-**Identical across all three models.** Temperature $1.0$, top-$p$ $0.9$ (or whatever
-you end up using). Same random seed per prompt across models. Any difference you see
-should be attributable to the model, not to sampling.
+**Keep them identical across all three models.** Temperature 1.0, top-p 0.9 (or
+whatever you settle on). Use the same random seed per prompt across models. Any
+difference you see should be attributable to the model, not to sampling
+variance.
 
-For deterministic comparison you can also generate with temperature 0 (greedy) — it's
-more boring but removes sampling noise.
+For a more deterministic comparison you can also generate with temperature 0
+(greedy). More boring to read, but removes all sampling noise so the differences
+are fully attributable to the model weights.
 
 ### 1.3 Format
 
@@ -49,7 +52,7 @@ A markdown table like:
 | 1 | ...    | ...  | ... | ...  |
 ```
 
-Paste it into this file under a "Results" section.
+Paste it under a "Results" section in this file.
 
 ---
 
@@ -57,89 +60,98 @@ Paste it into this file under a "Results" section.
 
 ### 2.1 Setup
 
-On the same 20 prompts, compare SFT vs RLHF responses pairwise. For each prompt:
+On the same 20 prompts, compare the SFT and RLHF responses pairwise. For each
+prompt:
 
 - Present both responses to yourself *without knowing which is which*. Write a
-  randomizer that swaps the order with 50% probability and keeps a hidden record.
+  simple randomizer that swaps the order with 50% probability and keeps the
+  answer hidden.
 - Rate one as "better" — more helpful, more accurate, more aligned with the
   instruction — or declare a tie.
 
 ### 2.2 Guarding against position bias
 
-Humans (and LLM judges) systematically prefer the first option they see. Mitigate:
+Humans (and LLM-as-judge evaluators) have a systematic preference for whichever
+option they see first. Two mitigations:
 
-- Randomize order (done above).
-- Over-sample and recompute: do the 20 comparisons, then re-do the same 20 with
-  reversed order, and average the two. If your judgments are consistent, the
-  randomizer is sufficient; otherwise average.
+- Randomize the order (you already did this above).
+- Run the 20 comparisons once, then re-run them with order reversed, and average
+  the results. If your ratings agree across the two passes, the randomizer was
+  enough; if they differ, averaging corrects the bias.
 
 ### 2.3 Scoring
 
-$$
-\text{win\_rate}_\text{RLHF} = \frac{\#\{\text{RLHF wins}\} + 0.5 \cdot \#\{\text{ties}\}}{20}.
-$$
+    win_rate_RLHF = (RLHF_wins + 0.5 * ties) / 20
 
-Target: $\ge 0.55$ (RLHF meaningfully better than SFT on a majority of held-out
-prompts). At $\le 0.5$, RLHF is no better than (or worse than) SFT — the run failed.
-Probable causes: weak reward model, $\beta$ too large so the policy barely moved, too
-few PPO iterations, reward hacking that doesn't look like hacking on these specific
-prompts.
+Target: at least 0.55 — RLHF is meaningfully better than SFT on a majority of
+prompts. If the win-rate is 0.5 or below, RLHF is no better than (or worse than)
+SFT and the run failed. Likely reasons:
+
+- Weak reward model.
+- `beta` too large — the policy barely moved from SFT.
+- Too few PPO iterations.
+- Reward hacking that isn't visible on these particular prompts.
 
 ### 2.4 If RLHF didn't win
 
-Don't paper over it. Write down:
+Don't paper over it. Write down honestly:
 
-- What the RLHF responses look like that SFT doesn't.
+- What the RLHF responses look like that SFT's don't.
 - What the RLHF responses are missing that you'd want.
-- Which hyperparameter you'd change next.
+- Which hyperparameter you'd change first, and why.
 
-Then actually change it and try again if you want to.
+Then actually change it and try again, if you want to.
 
 ---
 
 ## 3. The retrospective (Problem 6.3)
 
-One page. Answer these six questions directly:
+One page, answering these six questions directly.
 
 ### 3.1 What was the hardest part?
 
-Candidates from past RLHF projects include: PPO alignment between `logprobs_old`
-and `logprobs_new`; getting the shared-backbone / separate-value-head design right;
-the RM training and keeping pairwise accuracy above noise; memory management in
-PPO with four models.
+Some candidates from past RLHF projects: aligning `logprobs_old` and
+`logprobs_new` in the PPO loop; deciding between shared backbone and separate
+value network; getting RM pairwise accuracy above the noise floor; managing
+memory with four models loaded at once.
 
-### 3.2 Where did you spend the most time?
+### 3.2 Where did you actually spend the most time?
 
-Count your commits or your notes. The gap between how hard you thought it would be
-and how long it actually took is diagnostic.
+Count your commits and your notes. The gap between "how hard I thought it would
+be" and "how long it actually took" is diagnostic. Almost always, the answer
+reveals where your mental model was the weakest.
 
 ### 3.3 Which gradient check saved you?
 
-For every test in `tests/`, ask: did it catch a real bug? Which bug? Which tests were
-redundant? You'll use this to decide what to keep testing in the next project.
+For every test in `tests/`, ask yourself: did it catch a real bug? Which bug?
+Which tests were redundant? Use this to decide what to keep testing in your next
+project.
 
 ### 3.4 What would you do differently next time?
 
-Possible answers: separate value network; adaptive $\beta$; sample more prompts
-during rollout; use $k_3$ instead of $k_1$ for the KL penalty; handle length bias
-in the RM explicitly; start value head from SFT instead of zero.
+Candidates: separate value network; adaptive `beta`; sample more prompts during
+rollout; use `k_3` instead of `k_1` for the KL penalty; explicitly handle length
+bias in the RM; initialize the value head from SFT instead of zero.
 
 ### 3.5 What did you get wrong and fix?
 
-Trace back through your git history and identify bugs you caught during development:
-- Did you ever mask the wrong tokens in SFT? (e.g., included user turns, excluded
-  `<|im_end|>`, or used inverted mask).
-- Did you have an off-by-one or alignment bug in the PPO rollout (logprobs vs tokens)?
+Trace back through your git history and identify bugs you caught during
+development:
+
+- Did you ever mask the wrong tokens in SFT? (Included user turns? Forgot to
+  include `<|im_end|>`? Used an inverted mask?)
+- Did you have an off-by-one or alignment bug between logprobs and tokens in the
+  PPO rollout?
 - Did you forget to clip the value loss, or compute advantages without masking?
 
-These are the educational points of the exercise — real bugs that arise when implementing
-RLHF from scratch, and how you caught them.
+These are the educational points of the whole exercise — the real bugs that
+appear when you build RLHF from scratch, and how you learned to catch them.
 
 ### 3.6 What did you not understand before, and what do you understand now?
 
-Pick one thing. Write two paragraphs. "I used to think $X$; now I think $Y$." If
-you can't think of one, you didn't learn anything and you should do the course
-again. You *will* find one.
+Pick one thing. Write two paragraphs. "I used to think X; now I think Y." If you
+can't think of one, you didn't learn anything and you should redo the course.
+But you *will* find one.
 
 ---
 
@@ -149,4 +161,5 @@ again. You *will* find one.
 - The 20-row win-rate tally from 6.2 with your scoring notes.
 - The retrospective from 6.3.
 
-This is the last file in the curriculum. When it's complete, the course is complete.
+This is the last file in the curriculum. When it's complete, the course is
+complete.


### PR DESCRIPTION
Rewrite all nine notes in notes/*.md with plain-English-first explanations in
the style of Karpathy's nanoGPT guides. Replace dense LaTeX (\mathbb, \boxed,
\text{...} subscripts, etc.) with inline pseudocode and clear prose. Math is
still present where needed but every equation is explained in words before and
after. Target audience is a reader with basic PyTorch, undergrad linear
algebra, and undergrad calculus.

https://claude.ai/code/session_017CR44Q4a8TdssAtA5TnpFt