### PR TITLE
Improve SFT & PPO notes: readable LaTeX, clearer derivations, and math-to-code mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,12 @@ note before implementing the loss, and re-derive each gradient on paper as you g
 **1. Causal LM / SFT.**
 
 $$
-\mathcal{L} = -\frac{1}{N_\text{resp}} \sum_t m_t \, \log \mathrm{softmax}(W h_t)_{y_t}
+\mathcal{L} = -\frac{1}{N_{\mathrm{resp}}} \sum_t m_t \, \log \mathrm{softmax}(W h_t)_{y_t}
 $$
 
 $$
 \frac{\partial \mathcal{L}}{\partial \mathrm{logits}_t}
-= \frac{m_t}{N_\text{resp}} \left( \mathrm{softmax}(\mathrm{logits}_t) - \mathbf{1}_{y_t} \right)
+= \frac{m_t}{N_{\mathrm{resp}}} \left( \mathrm{softmax}(\mathrm{logits}_t) - \mathbf{1}_{y_t} \right)
 $$
 
 **2. Reward model (Bradley–Terry).**
@@ -136,7 +136,7 @@ Note the symmetry: the gradients sum to zero.
 **3. PPO clipped surrogate.**
 
 $$
-\rho_t = \exp(\log \pi_t - \log \pi_t^\text{old})
+\rho_t = \exp(\log \pi_t - \log \pi_t^{\mathrm{old}})
 $$
 
 $$
@@ -152,12 +152,12 @@ with $\mathrm{sign}(A_t)$.
 **4. KL penalty (per-token).**
 
 $$
-\mathrm{KL}_t \approx \log \pi_t - \log \pi_t^\text{ref}
-\qquad (k_1 \text{ estimator, unbiased, high variance})
+\mathrm{KL}_t \approx \log \pi_t - \log \pi_t^{\mathrm{ref}}
+\qquad (k_1 \;\mathrm{estimator,\ unbiased,\ high\ variance})
 $$
 
-Token reward: $r_t = r_\text{RM} \cdot \mathbf{1}_{t=T} - \beta \cdot \mathrm{KL}_t$.
-Since $\pi^\text{ref}$ is frozen: $\partial \mathrm{KL}_t / \partial \log \pi_t = 1$.
+Token reward: $r_t = r_{\mathrm{RM}} \cdot \mathbf{1}_{t=T} - \beta \cdot \mathrm{KL}_t$.
+Since $\pi^{\mathrm{ref}}$ is frozen: $\partial \mathrm{KL}_t / \partial \log \pi_t = 1$.
 
 The $k_3$ estimator $(\rho - 1) - \log \rho$ is nonnegative and lower-variance, preferred
 for logging but nonlinear in $\rho$ as a penalty.
@@ -166,7 +166,7 @@ for logging but nonlinear in $\rho$ as a penalty.
 
 $$
 \mathcal{L}_V = \tfrac{1}{2}(V_t - R_t)^2
-\qquad \text{(or clipped variant; see notes/04-ppo-policy.md)}
+\qquad \mathrm{(or\ clipped\ variant;\ see\ notes/04\text{-}ppo\text{-}policy.md)}
 $$
 
 $R_t$ is a stop-gradient constant even though it was computed from $V$ via GAE.
@@ -319,8 +319,8 @@ Explain the variance tradeoff in `notes/04-ppo-kl.md`.
 Artifact: unit test that k1 integrates to expected KL on a known distribution.
 
 **4.3 Reward shaping.**
-Terminal reward $r_\text{RM}$ from RM at `<|im_end|>`; per-token reward
-$r_t = -\beta \cdot \mathrm{KL}_t + r_\text{RM} \cdot \mathbf{1}_{t=T}$.
+Terminal reward $r_{\mathrm{RM}}$ from RM at `<|im_end|>`; per-token reward
+$r_t = -\beta \cdot \mathrm{KL}_t + r_{\mathrm{RM}} \cdot \mathbf{1}_{t=T}$.
 Test: $\beta \to 0$ collapses to pure RM terminal reward.
 Artifact: unit test passes.
 
@@ -345,7 +345,7 @@ Artifact: test_grad_ppo.py::test_ppo_policy_loss_grad passes.
 **4.6 Value loss (clipped).**
 
 $$
-\mathcal{L}_V = \tfrac{1}{2} \, \max\!\left( (V - R)^2, \; (\mathrm{clip}(V, V_\text{old} - \varepsilon_v, V_\text{old} + \varepsilon_v) - R)^2 \right) \cdot \mathrm{mask}
+\mathcal{L}_V = \tfrac{1}{2} \, \max\!\left( (V - R)^2, \; (\mathrm{clip}(V, V_{\mathrm{old}} - \varepsilon_v, V_{\mathrm{old}} + \varepsilon_v) - R)^2 \right) \cdot \mathrm{mask}
 $$
 
 Gradient-check. Explain why clipping value helps early training in `notes/04-ppo-policy.md`.
@@ -378,7 +378,7 @@ Artifact: one rollout iteration runs without error.
 
 **5.3 Inner loop (optimize phase).**
 For $K = 4$ epochs, iterate minibatches, compute
-$\mathcal{L} = \mathcal{L}_\pi + c_v \mathcal{L}_V - c_\text{ent} H$, backward, clip
+$\mathcal{L} = \mathcal{L}_\pi + c_v \mathcal{L}_V - c_{\mathrm{ent}} H$, backward, clip
 grad norm to 1.0, step. Recompute $\log \pi$ and $V$ freshly each minibatch;
 $\log \pi^\text{old}$ is frozen from rollout.
 Artifact: one full inner loop runs without error.

--- a/notes/00-data.md
+++ b/notes/00-data.md
@@ -6,6 +6,23 @@ Read this *before* you write `data_hh.py` (Problem 0.2). It's a data contract, n
 derivation. You're not doing math here — you're figuring out what the dataset looks like,
 what you need to produce from it, and how to format everything consistently.
 
+### Quick quantitative lens (light math, plain English)
+
+Even though this module is mostly data plumbing, it helps to formalize the summary
+stats you will compute:
+
+\[
+\text{len}_{\text{tok}}(x)=\text{number of GPT-2 BPE tokens in string }x
+\]
+
+\[
+p_q=\text{$q$-th percentile of }\{\text{len}_{\text{tok}}(x_i)\}_{i=1}^{N}
+\]
+
+In plain language: `p50` is your "typical length", `p95` is "long but common",
+and `p99` is "rare long tail". Those three numbers tell you where batching and
+padding will hurt most.
+
 ---
 
 ## 1. What is HH-RLHF?

--- a/notes/00-data.md
+++ b/notes/00-data.md
@@ -11,13 +11,13 @@ what you need to produce from it, and how to format everything consistently.
 Even though this module is mostly data plumbing, it helps to formalize the summary
 stats you will compute:
 
-\[
+$$
 \text{len}_{\text{tok}}(x)=\text{number of GPT-2 BPE tokens in string }x
-\]
+$$
 
-\[
+$$
 p_q=\text{$q$-th percentile of }\{\text{len}_{\text{tok}}(x_i)\}_{i=1}^{N}
-\]
+$$
 
 In plain language: `p50` is your "typical length", `p95` is "long but common",
 and `p99` is "rare long tail". Those three numbers tell you where batching and

--- a/notes/01-gpt2.md
+++ b/notes/01-gpt2.md
@@ -20,9 +20,9 @@ Notation we'll use throughout:
 
 The core language-model objective used throughout GPT-2 pretraining/fine-tuning is:
 
-\[
+$$
 \mathcal{L}_{\mathrm{LM}} = -\sum_{t=1}^{T-1}\log p_{\theta}(x_t\mid x_{<t})
-\]
+$$
 
 That equation maps almost 1:1 to code:
 

--- a/notes/01-gpt2.md
+++ b/notes/01-gpt2.md
@@ -16,6 +16,25 @@ Notation we'll use throughout:
 - `n_h` = number of attention heads (12 for small).
 - `d_h` = `C / n_h` = size of each head (64 for small).
 
+### Quick math map (derivation + implementation framing)
+
+The core language-model objective used throughout GPT-2 pretraining/fine-tuning is:
+
+\[
+\mathcal{L}_{\mathrm{LM}} = -\sum_{t=1}^{T-1}\log p_{\theta}(x_t\mid x_{<t})
+\]
+
+That equation maps almost 1:1 to code:
+
+```python
+logits = model(input_ids)          # (B, T, V)
+logp = F.log_softmax(logits[:, :-1], dim=-1)
+loss = -logp.gather(-1, labels[:, 1:].unsqueeze(-1)).mean()
+```
+
+Intuition: every next-token prediction is like a tiny exam question. The total
+loss is just "how surprised were we, on average, by the true next token?"
+
 ---
 
 ## 1. Big picture

--- a/notes/02-sft.md
+++ b/notes/02-sft.md
@@ -62,19 +62,19 @@ prediction counts toward the loss.
 At each position `t`, the model outputs a logit vector of length `V` (vocab size).
 Softmax converts logits to a probability distribution over the vocabulary:
 
-\[
+$$
 p_{t,v}=\frac{e^{z_{t,v}}}{\sum_{j=1}^{V} e^{z_{t,j}}}
-\]
+$$
 
 where `z` is just the logits tensor (`z == logits` in code).
 
 The cross-entropy loss at position `t` is the negative log-probability the model
 assigns to the true next token `y_t = labels[t]`:
 
-\[
+$$
 \ell_t=-\log p_{t,y_t}
 =-z_{t,y_t}+\log\!\left(\sum_{j=1}^{V} e^{z_{t,j}}\right)
-\]
+$$
 
 Quick intuition: logits are like raw "scores" for every token, softmax converts
 scores into odds, and cross-entropy measures how surprised we are by the correct
@@ -88,16 +88,16 @@ its log; that's numerically unstable.
 
 Summing across a batch of examples:
 
-\[
+$$
 L_{\text{SFT}}=
 \frac{\sum_{b,t} m_{b,t}\,\ell_{b,t}}
 {\sum_{b,t} m_{b,t}}
 =
 \frac{\sum_{b,t} m_{b,t}\,\ell_{b,t}}
 {N_{\text{resp}}}
-\]
+$$
 
-where \(N_{\text{resp}}=\sum_{b,t} m_{b,t}\) is the total number of assistant tokens
+where $N_{\text{resp}}=\sum_{b,t} m_{b,t}$ is the total number of assistant tokens
 in the batch.
 
 Dividing by `N_resp` (instead of by `B * T` or anything else) means the loss scale
@@ -172,7 +172,7 @@ by hand.
 
 ### 4.3 Chain rule (step-by-step, lighter notation)
 
-\[
+$$
 \frac{\partial \ell}{\partial z_u}
 =
 -\frac{1}{p_y}\frac{\partial p_y}{\partial z_u}
@@ -180,13 +180,13 @@ by hand.
 -\frac{1}{p_y}\,p_y\left(\mathbf{1}[u=y]-p_u\right)
 =
 p_u-\mathbf{1}[u=y]
-\]
+$$
 
 So in vector form:
 
-\[
+$$
 \nabla_z \ell = p-\mathrm{onehot}(y)
-\]
+$$
 
 Read this out loud: **"the gradient is the model's predicted distribution minus a
 delta spike on the correct class."**
@@ -204,11 +204,11 @@ class gets credited.
 
 Across positions `t`, with the mask factored in:
 
-\[
+$$
 \frac{\partial L_{\text{SFT}}}{\partial z_t}
 =
 \frac{m_t}{N_{\text{resp}}}\left(p_t-\mathrm{onehot}(y_t)\right)
-\]
+$$
 
 Three things worth noticing:
 

--- a/notes/02-sft.md
+++ b/notes/02-sft.md
@@ -57,18 +57,28 @@ From now on when we say "position `t`" we mean the shifted frame — so the mode
 logits at position `t` predict `labels[t]`, and `loss_mask[t]` tells us whether that
 prediction counts toward the loss.
 
-### 2.2 Per-token cross-entropy
+### 2.2 Per-token cross-entropy (LaTeX + code view)
 
 At each position `t`, the model outputs a logit vector of length `V` (vocab size).
 Softmax converts logits to a probability distribution over the vocabulary:
 
-    p[t, v] = exp(logit[t, v]) / sum over v' of exp(logit[t, v'])
+\[
+p_{t,v}=\frac{e^{z_{t,v}}}{\sum_{j=1}^{V} e^{z_{t,j}}}
+\]
+
+where `z` is just the logits tensor (`z == logits` in code).
 
 The cross-entropy loss at position `t` is the negative log-probability the model
 assigns to the true next token `y_t = labels[t]`:
 
-    ell[t] = -log p[t, y_t]
-           = -logit[t, y_t] + log(sum over v' of exp(logit[t, v']))
+\[
+\ell_t=-\log p_{t,y_t}
+=-z_{t,y_t}+\log\!\left(\sum_{j=1}^{V} e^{z_{t,j}}\right)
+\]
+
+Quick intuition: logits are like raw "scores" for every token, softmax converts
+scores into odds, and cross-entropy measures how surprised we are by the correct
+token. Low surprise means good prediction.
 
 The second form is what you actually compute — subtract the correct token's logit
 from the log-sum-exp of all logits. Never compute the softmax first and then take
@@ -78,9 +88,16 @@ its log; that's numerically unstable.
 
 Summing across a batch of examples:
 
-    L_SFT = sum over (b, t) of { m[b, t] * ell[b, t] }  /  N_resp
+\[
+L_{\text{SFT}}=
+\frac{\sum_{b,t} m_{b,t}\,\ell_{b,t}}
+{\sum_{b,t} m_{b,t}}
+=
+\frac{\sum_{b,t} m_{b,t}\,\ell_{b,t}}
+{N_{\text{resp}}}
+\]
 
-where `N_resp = sum over (b, t) of m[b, t]` is the total number of assistant tokens
+where \(N_{\text{resp}}=\sum_{b,t} m_{b,t}\) is the total number of assistant tokens
 in the batch.
 
 Dividing by `N_resp` (instead of by `B * T` or anything else) means the loss scale
@@ -153,15 +170,23 @@ where `delta(v, u)` is 1 if `v == u` and 0 otherwise. You get this by differenti
 `p[v] = exp(z[v]) / sum(exp(z))` and applying the quotient rule — worth doing once
 by hand.
 
-### 4.3 Chain rule
+### 4.3 Chain rule (step-by-step, lighter notation)
 
-    d ell / d z[u]  =  -1/p[y] * d p[y] / d z[u]
-                    =  -1/p[y] * p[y] * (delta(y, u) - p[u])
-                    =  p[u] - delta(y, u)
+\[
+\frac{\partial \ell}{\partial z_u}
+=
+-\frac{1}{p_y}\frac{\partial p_y}{\partial z_u}
+=
+-\frac{1}{p_y}\,p_y\left(\mathbf{1}[u=y]-p_u\right)
+=
+p_u-\mathbf{1}[u=y]
+\]
 
 So in vector form:
 
-    d ell / d z  =  p - onehot(y)
+\[
+\nabla_z \ell = p-\mathrm{onehot}(y)
+\]
 
 Read this out loud: **"the gradient is the model's predicted distribution minus a
 delta spike on the correct class."**
@@ -169,13 +194,21 @@ delta spike on the correct class."**
 Interpretation: the gradient subtracts probability mass from the true class and adds
 it to every other class, proportional to what the model currently predicts. A
 gradient step (minus this direction) pushes mass *toward* the correct class and *away
-from* every wrong class. Beautifully simple.
+from* every wrong class.
+
+Analogy: this is like rebalancing a budget where the "correct class" account should
+hold all the money. Classes with too much probability get debited, and the true
+class gets credited.
 
 ### 4.4 With the mask
 
 Across positions `t`, with the mask factored in:
 
-    d L_SFT / d z[t]  =  (m[t] / N_resp) * (p[t] - onehot(y[t]))
+\[
+\frac{\partial L_{\text{SFT}}}{\partial z_t}
+=
+\frac{m_t}{N_{\text{resp}}}\left(p_t-\mathrm{onehot}(y_t)\right)
+\]
 
 Three things worth noticing:
 

--- a/notes/03-rm.md
+++ b/notes/03-rm.md
@@ -20,15 +20,15 @@ By the end of this note you should be able to:
 
 The reward-model training objective in its stable form is:
 
-\[
+$$
 \mathcal{L}_{\mathrm{RM}}=\mathrm{softplus}(r_r-r_c)
-\]
+$$
 
 which is exactly equivalent to:
 
-\[
+$$
 \mathcal{L}_{\mathrm{RM}}=-\log \sigma(r_c-r_r)
-\]
+$$
 
 Plain English: if the chosen response (`r_c`) is already much higher than rejected
 (`r_r`), the loss is tiny. If the ranking is wrong, the loss is large and pushes

--- a/notes/03-rm.md
+++ b/notes/03-rm.md
@@ -16,6 +16,24 @@ By the end of this note you should be able to:
 5. Explain what "reward calibration" means and what you expect the score histograms
    to look like.
 
+### Quick formula-first view
+
+The reward-model training objective in its stable form is:
+
+\[
+\mathcal{L}_{\mathrm{RM}}=\mathrm{softplus}(r_r-r_c)
+\]
+
+which is exactly equivalent to:
+
+\[
+\mathcal{L}_{\mathrm{RM}}=-\log \sigma(r_c-r_r)
+\]
+
+Plain English: if the chosen response (`r_c`) is already much higher than rejected
+(`r_r`), the loss is tiny. If the ranking is wrong, the loss is large and pushes
+the two scores apart in the correct direction.
+
 ---
 
 ## 1. The goal in one sentence

--- a/notes/04-ppo-gae.md
+++ b/notes/04-ppo-gae.md
@@ -18,15 +18,15 @@ clipped surrogate, value loss, entropy). Read those after this one.
 
 Core objective:
 
-\[
+$$
 J(\theta)=\mathbb{E}_{\tau\sim\pi_\theta}\left[\sum_t \gamma^t r_t\right]
-\]
+$$
 
 Policy-gradient identity you keep reusing:
 
-\[
+$$
 \nabla_\theta J(\theta)=\mathbb{E}\left[\sum_t \nabla_\theta \log\pi_\theta(a_t\mid s_t)\,\hat A_t\right]
-\]
+$$
 
 Analogy: `\hat A_t` is a per-token "after-action report." Positive report means
 "do this kind of token more often in this context"; negative means "less often."

--- a/notes/04-ppo-gae.md
+++ b/notes/04-ppo-gae.md
@@ -14,6 +14,23 @@ covers:
 Related notes: `04-ppo-kl.md` (the KL penalty) and `04-ppo-policy.md` (the PPO
 clipped surrogate, value loss, entropy). Read those after this one.
 
+### Quick chain-rule roadmap (lighter notation)
+
+Core objective:
+
+\[
+J(\theta)=\mathbb{E}_{\tau\sim\pi_\theta}\left[\sum_t \gamma^t r_t\right]
+\]
+
+Policy-gradient identity you keep reusing:
+
+\[
+\nabla_\theta J(\theta)=\mathbb{E}\left[\sum_t \nabla_\theta \log\pi_\theta(a_t\mid s_t)\,\hat A_t\right]
+\]
+
+Analogy: `\hat A_t` is a per-token "after-action report." Positive report means
+"do this kind of token more often in this context"; negative means "less often."
+
 ---
 
 ## 1. Notation for RL on text

--- a/notes/04-ppo-kl.md
+++ b/notes/04-ppo-kl.md
@@ -18,16 +18,16 @@ By the end you should be able to:
 
 The KL target at a state is:
 
-\[
+$$
 \mathrm{KL}(\pi_\theta\Vert\pi_{\mathrm{ref}})
 =\mathbb{E}_{a\sim\pi_\theta}\!\left[\log\pi_\theta(a\mid s)-\log\pi_{\mathrm{ref}}(a\mid s)\right]
-\]
+$$
 
 Single-sample estimator used directly in reward shaping:
 
-\[
+$$
 k_1=\log\pi_\theta(a_t\mid s_t)-\log\pi_{\mathrm{ref}}(a_t\mid s_t)
-\]
+$$
 
 Plain English: if policy and reference agree, KL penalty is near zero; if policy
 pushes probability mass away from reference, the penalty increases and pushes back.

--- a/notes/04-ppo-kl.md
+++ b/notes/04-ppo-kl.md
@@ -14,6 +14,24 @@ By the end you should be able to:
    and why.
 4. Write down the per-token reward shaping used in InstructGPT-style PPO.
 
+### Quick estimator summary (math + interpretation)
+
+The KL target at a state is:
+
+\[
+\mathrm{KL}(\pi_\theta\Vert\pi_{\mathrm{ref}})
+=\mathbb{E}_{a\sim\pi_\theta}\!\left[\log\pi_\theta(a\mid s)-\log\pi_{\mathrm{ref}}(a\mid s)\right]
+\]
+
+Single-sample estimator used directly in reward shaping:
+
+\[
+k_1=\log\pi_\theta(a_t\mid s_t)-\log\pi_{\mathrm{ref}}(a_t\mid s_t)
+\]
+
+Plain English: if policy and reference agree, KL penalty is near zero; if policy
+pushes probability mass away from reference, the penalty increases and pushes back.
+
 ---
 
 ## 1. Why a KL penalty?

--- a/notes/04-ppo-policy.md
+++ b/notes/04-ppo-policy.md
@@ -5,7 +5,9 @@
 Theory packet for Problems 4.5, 4.6, and 4.7. Derive and reason about the three
 terms that make up the PPO loss:
 
-    L_PPO = L_policy + c_v * L_value - c_entropy * H
+\[
+L_{\mathrm{PPO}} = L_{\mathrm{policy}} + c_v L_{\mathrm{value}} - c_{\mathrm{entropy}} H
+\]
 
 By the end you should be able to:
 
@@ -21,7 +23,9 @@ By the end you should be able to:
 
 Recall from `04-ppo-gae.md` that the policy gradient with advantage baseline is:
 
-    grad J = E_{tau ~ pi_theta} [ sum_t grad log pi_theta(a_t | s_t) * A_t ]
+\[
+\nabla J(\theta)=\mathbb{E}_{\tau\sim\pi_{\theta}}\!\left[\sum_t \nabla \log \pi_{\theta}(a_t\mid s_t)\,A_t\right]
+\]
 
 **The problem.** To estimate this gradient, we need trajectories from the *current*
 policy `pi_theta`. But rolling out a batch of trajectories is expensive — each
@@ -34,12 +38,16 @@ expectation is no longer correct for the new policy.
 `pi_old`, frozen at the start of the current outer iteration. We rewrite the
 objective as an expectation under `pi_old` with an importance weight:
 
-    J(theta) = E_{tau ~ pi_old} [ sum_t rho_t(theta) * A_t ]
+\[
+J(\theta)=\mathbb{E}_{\tau\sim\pi_{\mathrm{old}}}\!\left[\sum_t \rho_t(\theta)\,A_t\right]
+\]
 
 where the **importance ratio** is:
 
-    rho_t(theta) = pi_theta(a_t | s_t) / pi_old(a_t | s_t)
-                 = exp( log pi_theta(a_t | s_t) - log pi_old(a_t | s_t) )
+\[
+\rho_t(\theta)=\frac{\pi_{\theta}(a_t\mid s_t)}{\pi_{\mathrm{old}}(a_t\mid s_t)}
+=\exp\!\big(\log \pi_{\theta}(a_t\mid s_t)-\log \pi_{\mathrm{old}}(a_t\mid s_t)\big)
+\]
 
 As long as `pi_theta` stays close to `pi_old`, the gradient of this rewritten
 expression equals the policy gradient.
@@ -57,19 +65,25 @@ the batch while preventing the policy from moving too far per update.
 
 For each token, define two candidate surrogates:
 
-    surr1 = rho * A
-    surr2 = clip(rho, 1 - epsilon, 1 + epsilon) * A
+\[
+\mathrm{surr}_1 = \rho A,\qquad
+\mathrm{surr}_2 = \mathrm{clip}(\rho, 1-\epsilon, 1+\epsilon)A
+\]
 
 where `clip(x, lo, hi)` pins `x` to the range `[lo, hi]`. `epsilon` is typically
 0.2.
 
 The PPO per-token loss is:
 
-    L_clip_t = - min(surr1, surr2)
+\[
+L_t^{\mathrm{clip}}=-\min(\mathrm{surr}_1,\mathrm{surr}_2)
+\]
 
 And the total policy loss:
 
-    L_policy = (1 / N) * sum over (b, t) of mask[b, t] * L_clip[b, t]
+\[
+L_{\mathrm{policy}}=\frac{1}{N}\sum_{b,t}\mathrm{mask}_{b,t}\,L_{b,t}^{\mathrm{clip}}
+\]
 
 where `N` is the count of masked-in response tokens.
 
@@ -110,7 +124,12 @@ For the unclipped case, the per-token loss is `L = -rho * A`. Using
 
 So:
 
-    d L / d log pi_theta = -A * rho
+\[
+\frac{\partial L}{\partial \log \pi_{\theta}} = -A\rho
+\]
+
+Simple intuition: `A` says whether to increase or decrease the chosen action's
+log-probability, while `\rho` sets how aggressively we do it.
 
 At `rho = 1` (on-policy limit), this simplifies to `-A`, which recovers the
 vanilla policy gradient direction.
@@ -118,9 +137,23 @@ vanilla policy gradient direction.
 For the clipped case, `surr2 = (a constant with respect to theta) * A`. The
 clip saturates, so changing `log pi_theta` doesn't change `surr2`. Therefore:
 
-    d L / d log pi_theta = 0
+\[
+\frac{\partial L}{\partial \log \pi_{\theta}} = 0
+\]
 
 That token contributes zero signal to this gradient step.
+
+Equivalent code shape (for one token) is:
+
+```python
+ratio = torch.exp(logp_new - logp_old)
+surr1 = ratio * adv
+surr2 = torch.clamp(ratio, 1 - eps, 1 + eps) * adv
+loss_tok = -torch.minimum(surr1, surr2)
+```
+
+This is a useful "math-to-code" checkpoint: each symbol in the derivation has a
+one-line implementation, and the clipping behavior is visually obvious.
 
 Verify this with an **edge test** in Problem 4.5. Set every ratio to a large
 value (say `rho = 5`) and `A > 0`. Every token should land in the "A > 0,
@@ -232,37 +265,53 @@ near zero, generations getting repetitive), bump it to `0.01`.
 
 For one position, the entropy of the per-token distribution `p` over the vocab is:
 
-    H(p) = - sum over v of p[v] * log p[v]
+\[
+H(p) = -\sum_v p_v \log p_v
+\]
 
 For a batch of positions:
 
-    H_batch = (1 / N) * sum over (b, t) of mask[b, t] * H(p[b, t])
+\[
+H_{\mathrm{batch}}=\frac{1}{N}\sum_{b,t}\mathrm{mask}_{b,t}\,H(p_{b,t})
+\]
 
 ### 4.3 Gradient of `H` with respect to logits
 
 Let `z` be the logits and `p = softmax(z)`. Using the softmax derivative
 `d p[v] / d z[u] = p[v] * (delta(v, u) - p[u])` from `02-sft.md`:
 
-    d H / d z[u]
-    = - sum over v of (d p[v] / d z[u]) * (log p[v] + 1)
-    = - sum over v of p[v] * (delta(v, u) - p[u]) * (log p[v] + 1)
+\[
+\frac{\partial H}{\partial z_u}
+=-\sum_v \frac{\partial p_v}{\partial z_u}(\log p_v + 1)
+=-\sum_v p_v\big(\mathbf{1}[v=u]-p_u\big)(\log p_v+1)
+\]
 
 Expand:
 
-    = - p[u] * (log p[u] + 1)  +  p[u] * sum over v of p[v] * (log p[v] + 1)
+\[
+=-p_u(\log p_u+1)+p_u\sum_v p_v(\log p_v+1)
+\]
 
 The sum on the right equals `-H + 1`, since `sum_v p[v] * log p[v] = -H` and
 `sum_v p[v] = 1`. So:
 
-    d H / d z[u]
-    = - p[u] * (log p[u] + 1)  +  p[u] * (-H + 1)
-    = - p[u] * (log p[u] + H)
+\[
+\frac{\partial H}{\partial z_u}
+=-p_u(\log p_u+1)+p_u(-H+1)
+=-p_u(\log p_u+H)
+\]
 
 In vector form:
 
-    d H / d z  =  - p * (log p + H)
+\[
+\nabla_z H = -p \odot (\log p + H)
+\]
 
-(elementwise product).
+where `\odot` means elementwise product.
+
+Analogy: entropy is like "spread." If probability gets too concentrated on one
+token, this gradient behaves like a spring that pulls the distribution back toward
+a broader shape.
 
 ### 4.4 Sanity check
 

--- a/notes/04-ppo-policy.md
+++ b/notes/04-ppo-policy.md
@@ -5,9 +5,9 @@
 Theory packet for Problems 4.5, 4.6, and 4.7. Derive and reason about the three
 terms that make up the PPO loss:
 
-\[
+$$
 L_{\mathrm{PPO}} = L_{\mathrm{policy}} + c_v L_{\mathrm{value}} - c_{\mathrm{entropy}} H
-\]
+$$
 
 By the end you should be able to:
 
@@ -23,9 +23,9 @@ By the end you should be able to:
 
 Recall from `04-ppo-gae.md` that the policy gradient with advantage baseline is:
 
-\[
+$$
 \nabla J(\theta)=\mathbb{E}_{\tau\sim\pi_{\theta}}\!\left[\sum_t \nabla \log \pi_{\theta}(a_t\mid s_t)\,A_t\right]
-\]
+$$
 
 **The problem.** To estimate this gradient, we need trajectories from the *current*
 policy `pi_theta`. But rolling out a batch of trajectories is expensive — each
@@ -38,16 +38,16 @@ expectation is no longer correct for the new policy.
 `pi_old`, frozen at the start of the current outer iteration. We rewrite the
 objective as an expectation under `pi_old` with an importance weight:
 
-\[
+$$
 J(\theta)=\mathbb{E}_{\tau\sim\pi_{\mathrm{old}}}\!\left[\sum_t \rho_t(\theta)\,A_t\right]
-\]
+$$
 
 where the **importance ratio** is:
 
-\[
+$$
 \rho_t(\theta)=\frac{\pi_{\theta}(a_t\mid s_t)}{\pi_{\mathrm{old}}(a_t\mid s_t)}
 =\exp\!\big(\log \pi_{\theta}(a_t\mid s_t)-\log \pi_{\mathrm{old}}(a_t\mid s_t)\big)
-\]
+$$
 
 As long as `pi_theta` stays close to `pi_old`, the gradient of this rewritten
 expression equals the policy gradient.
@@ -65,25 +65,25 @@ the batch while preventing the policy from moving too far per update.
 
 For each token, define two candidate surrogates:
 
-\[
+$$
 \mathrm{surr}_1 = \rho A,\qquad
 \mathrm{surr}_2 = \mathrm{clip}(\rho, 1-\epsilon, 1+\epsilon)A
-\]
+$$
 
 where `clip(x, lo, hi)` pins `x` to the range `[lo, hi]`. `epsilon` is typically
 0.2.
 
 The PPO per-token loss is:
 
-\[
+$$
 L_t^{\mathrm{clip}}=-\min(\mathrm{surr}_1,\mathrm{surr}_2)
-\]
+$$
 
 And the total policy loss:
 
-\[
+$$
 L_{\mathrm{policy}}=\frac{1}{N}\sum_{b,t}\mathrm{mask}_{b,t}\,L_{b,t}^{\mathrm{clip}}
-\]
+$$
 
 where `N` is the count of masked-in response tokens.
 
@@ -124,9 +124,9 @@ For the unclipped case, the per-token loss is `L = -rho * A`. Using
 
 So:
 
-\[
+$$
 \frac{\partial L}{\partial \log \pi_{\theta}} = -A\rho
-\]
+$$
 
 Simple intuition: `A` says whether to increase or decrease the chosen action's
 log-probability, while `\rho` sets how aggressively we do it.
@@ -137,9 +137,9 @@ vanilla policy gradient direction.
 For the clipped case, `surr2 = (a constant with respect to theta) * A`. The
 clip saturates, so changing `log pi_theta` doesn't change `surr2`. Therefore:
 
-\[
+$$
 \frac{\partial L}{\partial \log \pi_{\theta}} = 0
-\]
+$$
 
 That token contributes zero signal to this gradient step.
 
@@ -265,47 +265,47 @@ near zero, generations getting repetitive), bump it to `0.01`.
 
 For one position, the entropy of the per-token distribution `p` over the vocab is:
 
-\[
+$$
 H(p) = -\sum_v p_v \log p_v
-\]
+$$
 
 For a batch of positions:
 
-\[
+$$
 H_{\mathrm{batch}}=\frac{1}{N}\sum_{b,t}\mathrm{mask}_{b,t}\,H(p_{b,t})
-\]
+$$
 
 ### 4.3 Gradient of `H` with respect to logits
 
 Let `z` be the logits and `p = softmax(z)`. Using the softmax derivative
 `d p[v] / d z[u] = p[v] * (delta(v, u) - p[u])` from `02-sft.md`:
 
-\[
+$$
 \frac{\partial H}{\partial z_u}
 =-\sum_v \frac{\partial p_v}{\partial z_u}(\log p_v + 1)
 =-\sum_v p_v\big(\mathbf{1}[v=u]-p_u\big)(\log p_v+1)
-\]
+$$
 
 Expand:
 
-\[
+$$
 =-p_u(\log p_u+1)+p_u\sum_v p_v(\log p_v+1)
-\]
+$$
 
 The sum on the right equals `-H + 1`, since `sum_v p[v] * log p[v] = -H` and
 `sum_v p[v] = 1`. So:
 
-\[
+$$
 \frac{\partial H}{\partial z_u}
 =-p_u(\log p_u+1)+p_u(-H+1)
 =-p_u(\log p_u+H)
-\]
+$$
 
 In vector form:
 
-\[
+$$
 \nabla_z H = -p \odot (\log p + H)
-\]
+$$
 
 where `\odot` means elementwise product.
 

--- a/notes/05-ppo.md
+++ b/notes/05-ppo.md
@@ -12,6 +12,24 @@ all in `04-*.md`. This note zooms out and talks about:
 4. How to make the code work for all four GPT-2 sizes, even if the larger ones
    OOM.
 
+### Quick objective recap in one place
+
+PPO optimization in this repo uses:
+
+\[
+\mathcal{L}_{\mathrm{total}}
+\;=\;
+\mathcal{L}_{\mathrm{policy}}
+\;+\;
+c_v\,\mathcal{L}_{\mathrm{value}}
+\;-\;
+c_e\,H
+\]
+
+where `H` is policy entropy. In plain terms: improve actions (`policy`), improve
+critic calibration (`value`), and avoid collapsing too quickly to deterministic
+token choices (`entropy`).
+
 ---
 
 ## 1. The four models

--- a/notes/05-ppo.md
+++ b/notes/05-ppo.md
@@ -16,7 +16,7 @@ all in `04-*.md`. This note zooms out and talks about:
 
 PPO optimization in this repo uses:
 
-\[
+$$
 \mathcal{L}_{\mathrm{total}}
 \;=\;
 \mathcal{L}_{\mathrm{policy}}
@@ -24,7 +24,7 @@ PPO optimization in this repo uses:
 c_v\,\mathcal{L}_{\mathrm{value}}
 \;-\;
 c_e\,H
-\]
+$$
 
 where `H` is policy entropy. In plain terms: improve actions (`policy`), improve
 critic calibration (`value`), and avoid collapsing too quickly to deterministic

--- a/notes/06-eval.md
+++ b/notes/06-eval.md
@@ -11,6 +11,19 @@ at this stage — the theory is all behind you. This note is about:
 
 Fill this file in with your actual outputs as you run the problems.
 
+### Quick metric formula (with tie handling)
+
+Use the tie-aware win rate:
+
+\[
+\mathrm{win\_rate}_{\mathrm{RLHF}}
+=
+\frac{W_{\mathrm{RLHF}} + 0.5\,T}{N}
+\]
+
+where \(W_{\mathrm{RLHF}}\) is RLHF wins, \(T\) is ties, and \(N\) is number of
+prompts judged. Think of each tie as "half a win" so the metric stays fair.
+
 ---
 
 ## 1. Generation comparison (Problem 6.1)

--- a/notes/06-eval.md
+++ b/notes/06-eval.md
@@ -15,13 +15,13 @@ Fill this file in with your actual outputs as you run the problems.
 
 Use the tie-aware win rate:
 
-\[
+$$
 \mathrm{win\_rate}_{\mathrm{RLHF}}
 =
 \frac{W_{\mathrm{RLHF}} + 0.5\,T}{N}
-\]
+$$
 
-where \(W_{\mathrm{RLHF}}\) is RLHF wins, \(T\) is ties, and \(N\) is number of
+where $W_{\mathrm{RLHF}}$ is RLHF wins, $T$ is ties, and $N$ is number of
 prompts judged. Think of each tie as "half a win" so the metric stays fair.
 
 ---


### PR DESCRIPTION
### Motivation
- Make the course notes easier to parse by restoring readable LaTeX block math while keeping plain-text and code explanations so readers of varied backgrounds can follow derivations. 
- Present chain-rule and entropy derivations with lighter notation and more prose/analogies so the math is easier to grok without losing correctness. 
- Provide a direct mapping from the math to implementation with a short PPO math-to-code checkpoint to reduce translation mistakes when implementing the loss.

### Description
- Rewrote key math presentations in `notes/02-sft.md` to use display LaTeX for softmax, cross-entropy, masked-batch averaging, and the gradient; added a step-by-step chain-rule derivation, an intuition paragraph, and an analogy. (file: `notes/02-sft.md`)
- Updated `notes/04-ppo-policy.md` to include display LaTeX for the PPO objective, importance ratio, clipped surrogate, and entropy formulas; added clearer prose and a short PyTorch snippet that implements the clipped PPO per-token loss to show the math-to-code mapping. (file: `notes/04-ppo-policy.md`)
- Small readability/formatting improvements around derivations (lighter notation, `
`-separated LaTeX blocks and brief plain-language interpretations) to ensure both full derivations and accessible explanations are present.

### Testing
- Ran `pytest -q`; test collection failed during setup due to external resource download being blocked for the tokenizer (`tiktoken` attempted to fetch GPT-2 BPE data and the environment returned a proxy 403), so unit tests could not be executed in this environment.  
- No unit-test regressions were observed locally in file edits (only documentation/notes were changed), and basic file sanity checks for control characters were performed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba4ead0bc8322a06011108f93a4cf)