### PR TITLE
Add LaTeX equations and improve mathematical notation in theory notes

### DIFF
--- a/notes/01-gpt2.md
+++ b/notes/01-gpt2.md
@@ -77,6 +77,12 @@ GPT-2 has two learned lookup tables:
 
 The first layer of the model is just:
 
+$$
+h_0[b, t] \;=\; \mathrm{wte}\bigl[\mathrm{input\_ids}[b, t]\bigr] \,+\, \mathrm{wpe}[t]
+$$
+
+Or in code-style:
+
     h_0[b, t] = wte[input_ids[b, t]] + wpe[t]
 
 That's it. Two lookups, one elementwise add. Both tables are `nn.Embedding` modules —
@@ -96,15 +102,29 @@ LayerNorm normalizes each token's hidden vector independently. "Independently" m
 for each (batch, time) position, we look at the `C`-dimensional hidden vector at that
 position and normalize *within* it. We do not mix across batch or across time.
 
-Here's what it does in four steps:
+Here's what it does, in equations. For a single token's hidden vector $x \in \mathbb{R}^C$:
 
-1. Compute the **mean** of the `C` values.
-2. Compute the **variance** of the `C` values (using `C` in the denominator, i.e.
-   biased variance — *not* `C - 1`).
-3. Subtract the mean and divide by `sqrt(variance + eps)`. This gives a vector with
-   zero mean and unit variance.
-4. Multiply by a learned per-channel scale `gamma` and add a learned per-channel bias
-   `beta`.
+$$
+\mu \;=\; \frac{1}{C} \sum_{i=1}^{C} x_i,
+\qquad
+\sigma^2 \;=\; \frac{1}{C} \sum_{i=1}^{C} (x_i - \mu)^2
+$$
+
+$$
+\hat x_i \;=\; \frac{x_i - \mu}{\sqrt{\sigma^2 + \varepsilon}},
+\qquad
+y_i \;=\; \gamma_i \cdot \hat x_i \,+\, \beta_i
+$$
+
+In words, four steps:
+
+1. Compute the **mean** of the $C$ values.
+2. Compute the **variance** of the $C$ values (using $C$ in the denominator, i.e.
+   biased variance — *not* $C - 1$).
+3. Subtract the mean and divide by $\sqrt{\sigma^2 + \varepsilon}$. This gives a
+   vector with zero mean and unit variance.
+4. Multiply by a learned per-channel scale $\gamma$ and add a learned per-channel bias
+   $\beta$.
 
 The scale and bias (each of shape `(C,)`) let the network undo the normalization if
 that's what it wants — so we're really just *reparameterizing* the hidden state
@@ -161,6 +181,12 @@ represent?), and a "value" (what information do I carry?).
 
 For a single head, compute the dot product of every query with every key:
 
+$$
+S_{t, s} \;=\; \frac{Q_t \cdot K_s}{\sqrt{d_h}}
+$$
+
+Or in code-style:
+
     S[t, s] = (Q[t] . K[s]) / sqrt(d_h)
 
 `S` is shape `(T, T)`. Each entry `S[t, s]` tells us how much position `t` wants to
@@ -181,6 +207,12 @@ performance.
 
 Apply softmax along the "keys" axis (the `s` dimension):
 
+$$
+\alpha_{t, s} \;=\; \frac{\exp(S_{t, s})}{\sum_{s'} \exp(S_{t, s'})}
+$$
+
+Or in code-style:
+
     alpha[t, s] = exp(S[t, s]) / sum over s' of exp(S[t, s'])
 
 The result `alpha` has shape `(T, T)` and each row sums to 1. Each row is a
@@ -189,6 +221,12 @@ probability distribution over "which earlier positions to attend to".
 ### 4.5 Weighted sum of values
 
 For each position `t`, mix the value vectors using `alpha` as the weights:
+
+$$
+o_t \;=\; \sum_s \alpha_{t, s} \cdot V_s
+$$
+
+Or in code-style:
 
     o[t] = sum over s of alpha[t, s] * V[s]
 
@@ -245,8 +283,14 @@ of ReLU: instead of a hard "zero if negative, x if positive" kink at zero, GELU
 transitions smoothly around zero, looking roughly like `x` times a soft gate that is
 close to 0 for very negative `x` and close to 1 for very positive `x`.
 
-The exact definition uses the standard normal CDF (the probability that a standard
-normal is less than `x`):
+The exact definition uses the standard normal CDF $\Phi$ (the probability that a
+standard normal is less than $x$):
+
+$$
+\mathrm{GELU}(x) \;=\; x \cdot \Phi(x)
+$$
+
+Or in code-style:
 
     GELU(x) = x * Phi(x)
 
@@ -399,7 +443,13 @@ you'll implement.
 
 ### Temperature
 
-Before softmax, divide logits by `tau`:
+Before softmax, divide logits by $\tau$:
+
+$$
+p_v \;=\; \frac{\exp(z_v / \tau)}{\sum_{v'} \exp(z_{v'} / \tau)}
+$$
+
+Or in code-style:
 
     p[v] = exp(logit[v] / tau) / sum over v' of exp(logit[v'] / tau)
 

--- a/notes/02-sft.md
+++ b/notes/02-sft.md
@@ -59,29 +59,61 @@ prediction counts toward the loss.
 
 ### 2.2 Per-token cross-entropy
 
-At each position `t`, the model outputs a logit vector of length `V` (vocab size).
-Softmax converts logits to a probability distribution over the vocabulary:
+At each position `t`, the model outputs a logit vector $z_t$ of length `V` (vocab
+size). Softmax converts logits to a probability distribution over the vocabulary:
 
-    p[t, v] = exp(logit[t, v]) / sum over v' of exp(logit[t, v'])
+$$
+p_{t,v} \;=\; \frac{\exp(z_{t,v})}{\sum_{v'} \exp(z_{t,v'})}
+$$
+
+Or in code-style:
+
+    p[t, v] = exp(z[t, v]) / sum over v' of exp(z[t, v'])
+
+Intuition: the logits are unconstrained real numbers; softmax is the function that
+turns an arbitrary vector of real numbers into a legal probability distribution (all
+entries non-negative and summing to 1). The exponential makes things positive; the
+division by the sum normalizes them. Same recipe you'd use to turn any list of
+"scores" into a distribution.
 
 The cross-entropy loss at position `t` is the negative log-probability the model
-assigns to the true next token `y_t = labels[t]`:
+assigns to the true next token $y_t = \text{labels}[t]$:
+
+$$
+\ell_t \;=\; -\log p_{t,y_t} \;=\; -z_{t,y_t} \;+\; \log \sum_{v'} \exp(z_{t,v'})
+$$
+
+Or in code-style:
 
     ell[t] = -log p[t, y_t]
-           = -logit[t, y_t] + log(sum over v' of exp(logit[t, v']))
+           = -z[t, y_t] + log(sum over v' of exp(z[t, v']))
 
-The second form is what you actually compute — subtract the correct token's logit
-from the log-sum-exp of all logits. Never compute the softmax first and then take
-its log; that's numerically unstable.
+The second form — "correct-class logit, minus the log-sum-exp of all logits" — is
+what you actually compute. Never compute the softmax first and then take its log;
+the softmax can underflow to zero and `log(0)` blows up. The `log_softmax` op in
+PyTorch uses the log-sum-exp trick internally to stay numerically stable.
+
+Intuition for the loss: `-log p` is tiny (close to 0) when the model is confident and
+correct, and huge (goes to infinity) when the model is confident and wrong. It's a
+surprise. We're training the model to minimize surprise on the assistant tokens we
+want it to produce.
 
 ### 2.3 Masked mean over the batch
 
-Summing across a batch of examples:
+Summing across a batch of examples, indexed by `(b, t)`:
 
-    L_SFT = sum over (b, t) of { m[b, t] * ell[b, t] }  /  N_resp
+$$
+L_{\mathrm{SFT}} \;=\; \frac{1}{N_{\mathrm{resp}}} \sum_{b, t} m_{b,t} \cdot \ell_{b,t},
+\qquad
+N_{\mathrm{resp}} \;=\; \sum_{b, t} m_{b,t}
+$$
 
-where `N_resp = sum over (b, t) of m[b, t]` is the total number of assistant tokens
-in the batch.
+Or in code-style:
+
+    L_SFT  =  sum over (b, t) of { m[b, t] * ell[b, t] }  /  N_resp
+    N_resp =  sum over (b, t) of m[b, t]
+
+$N_{\mathrm{resp}}$ is the total number of assistant tokens in the batch.
 
 Dividing by `N_resp` (instead of by `B * T` or anything else) means the loss scale
 doesn't depend on how much padding happened to be in the batch. Padding tokens
@@ -135,45 +167,120 @@ mechanics.
 
 ### 4.1 Setup
 
-Fix one position for now. Let `z` be the length-`V` vector of logits and let `p` be
-the softmax of `z`. Let `y` be the index of the correct class. The loss at this
+Fix one position for now. Let $z$ be the length-$V$ vector of logits and let $p$ be
+the softmax of $z$. Let $y$ be the index of the correct class. The loss at this
 position is:
 
-    ell = -log p[y]
+$$
+\ell \;=\; -\log p_y
+$$
 
-We want `d ell / d z` — the gradient of the loss with respect to the logits.
+We want $\partial \ell / \partial z$ — the gradient of the loss with respect to the
+logits. Our plan is the usual one: compute it by the chain rule, breaking the
+derivative into two pieces — how the loss changes with the probability, and how the
+probability changes with the logit.
 
 ### 4.2 Softmax derivative
 
-For any two indices `v` and `u`:
+For any two indices $v$ and $u$ we have:
+
+$$
+\frac{\partial p_v}{\partial z_u} \;=\; p_v \cdot (\delta_{v,u} \,-\, p_u)
+$$
+
+where $\delta_{v,u}$ is the Kronecker delta (reads: "1 if the subscripts are equal,
+0 otherwise"). In code-style:
 
     d p[v] / d z[u] = p[v] * (delta(v, u) - p[u])
 
-where `delta(v, u)` is 1 if `v == u` and 0 otherwise. You get this by differentiating
-`p[v] = exp(z[v]) / sum(exp(z))` and applying the quotient rule — worth doing once
-by hand.
+Derive this once yourself. Start from $p_v = \exp(z_v) / S$ where
+$S = \sum_{v'} \exp(z_{v'})$, and use the quotient rule:
+
+$$
+\frac{\partial p_v}{\partial z_u}
+\;=\; \frac{(\partial \exp(z_v)/\partial z_u) \cdot S \,-\, \exp(z_v) \cdot (\partial S/\partial z_u)}{S^2}
+$$
+
+The first derivative in the numerator is $\exp(z_v) \cdot \delta_{v,u}$ (since
+$\exp(z_v)$ depends on $z_u$ only when $v = u$). The second is
+$\partial S/\partial z_u = \exp(z_u)$. Plug in and collect terms:
+
+$$
+\frac{\partial p_v}{\partial z_u}
+\;=\; \frac{\exp(z_v)}{S} \delta_{v,u} \;-\; \frac{\exp(z_v)}{S} \cdot \frac{\exp(z_u)}{S}
+\;=\; p_v \delta_{v,u} \;-\; p_v p_u
+\;=\; p_v (\delta_{v,u} - p_u)
+$$
+
+Done. This result is worth memorizing — it shows up every time you differentiate a
+softmax.
 
 ### 4.3 Chain rule
 
-    d ell / d z[u]  =  -1/p[y] * d p[y] / d z[u]
-                    =  -1/p[y] * p[y] * (delta(y, u) - p[u])
-                    =  p[u] - delta(y, u)
+Now stitch together "how does $\ell$ depend on $p_y$" with "how does $p_y$ depend on
+$z_u$":
 
-So in vector form:
+$$
+\frac{\partial \ell}{\partial z_u}
+\;=\; \frac{\partial \ell}{\partial p_y} \cdot \frac{\partial p_y}{\partial z_u}
+$$
+
+The first factor comes from $\ell = -\log p_y$:
+
+$$
+\frac{\partial \ell}{\partial p_y} \;=\; -\frac{1}{p_y}
+$$
+
+The second factor we just computed (plug $v = y$):
+
+$$
+\frac{\partial p_y}{\partial z_u} \;=\; p_y (\delta_{y,u} - p_u)
+$$
+
+Multiply them:
+
+$$
+\frac{\partial \ell}{\partial z_u}
+\;=\; -\frac{1}{p_y} \cdot p_y (\delta_{y,u} - p_u)
+\;=\; -(\delta_{y,u} - p_u)
+\;=\; p_u - \delta_{y,u}
+$$
+
+The $p_y$ cancels beautifully. In vector form:
+
+$$
+\frac{\partial \ell}{\partial z} \;=\; p \,-\, e_y
+$$
+
+where $e_y$ is the one-hot vector with a 1 at index $y$ and 0 elsewhere. Or in
+code-style:
 
     d ell / d z  =  p - onehot(y)
 
 Read this out loud: **"the gradient is the model's predicted distribution minus a
-delta spike on the correct class."**
+spike on the correct class."**
 
 Interpretation: the gradient subtracts probability mass from the true class and adds
 it to every other class, proportional to what the model currently predicts. A
-gradient step (minus this direction) pushes mass *toward* the correct class and *away
-from* every wrong class. Beautifully simple.
+gradient *step* (minus this direction) pushes mass *toward* the correct class and
+*away from* every wrong class. Every update is a small rebalancing.
+
+An analogy that helps: imagine each class as a bucket, and $p$ as how full each
+bucket is with water. The true bucket is $y$. The gradient says "drain a little
+water from every bucket in proportion to how full it is, then dump an equal total
+amount into bucket $y$." After many steps, bucket $y$ is full and everything else
+is nearly empty — which is exactly what confident, correct prediction looks like.
 
 ### 4.4 With the mask
 
 Across positions `t`, with the mask factored in:
+
+$$
+\frac{\partial L_{\mathrm{SFT}}}{\partial z_t}
+\;=\; \frac{m_t}{N_{\mathrm{resp}}} \cdot (p_t - e_{y_t})
+$$
+
+Or in code-style:
 
     d L_SFT / d z[t]  =  (m[t] / N_resp) * (p[t] - onehot(y[t]))
 

--- a/notes/03-rm.md
+++ b/notes/03-rm.md
@@ -20,10 +20,16 @@ By the end of this note you should be able to:
 
 ## 1. The goal in one sentence
 
-We have a preference dataset of pairs `(y_c, y_r)` — chosen and rejected completions.
-We want to learn a scalar function `r(y)` (where `y` is a full prompt + response)
+We have a preference dataset of pairs $(y_c, y_r)$ — chosen and rejected completions.
+We want to learn a scalar function $r(y)$ (where $y$ is a full prompt + response)
 such that, on average, the chosen completion gets a higher score than the rejected
 one:
+
+$$
+\mathbb{E}\,[\, r(y_c) \,-\, r(y_r) \,] \;>\; 0
+$$
+
+Or in code-style:
 
     r(y_c) > r(y_r)     in expectation
 
@@ -37,19 +43,31 @@ ranked above `y_r`". That's exactly what the Bradley–Terry model gives us.
 
 ### 2.1 The model
 
-Imagine that every completion `y` has some hidden "true quality" score `r(y)`. When
+Imagine that every completion $y$ has some hidden "true quality" score $r(y)$. When
 a human compares two completions, they pick the one with higher true score, but they
 do it *noisily* — sometimes they pick the worse one, more often when the two are
 close in quality. Specifically, Bradley–Terry assumes:
 
+$$
+P(\text{human picks } y_c \text{ over } y_r) \;=\; \sigma\bigl(r(y_c) - r(y_r)\bigr)
+$$
+
+where $\sigma$ is the logistic sigmoid,
+
+$$
+\sigma(x) \;=\; \frac{1}{1 + e^{-x}}
+$$
+
+Or in code-style:
+
     P(human picks y_c over y_r) = sigmoid(r(y_c) - r(y_r))
+    sigmoid(x) = 1 / (1 + exp(-x))
 
-where `sigmoid(x) = 1 / (1 + exp(-x))`.
-
-Check that this makes sense: if `r(y_c) >> r(y_r)`, sigmoid goes to 1 — the human
-almost always picks the chosen one. If the two scores are equal, sigmoid is 0.5 — a
-coin flip. And if `r(y_c) << r(y_r)`, sigmoid goes to 0 — the human rarely picks the
-"chosen" one (the labeler made a bad call, which happens).
+Check that this makes sense. If $r(y_c) \gg r(y_r)$, the sigmoid argument is very
+positive and $\sigma \to 1$ — the human almost always picks the chosen one. If the
+two scores are equal, $\sigma(0) = 0.5$ — a coin flip. And if $r(y_c) \ll r(y_r)$,
+$\sigma \to 0$ — the human rarely picks the "chosen" one (the labeler made a bad
+call, which happens).
 
 This model comes from Bradley & Terry (1952) and is the same math behind Elo ratings
 in chess or ranking systems in sports.
@@ -62,12 +80,20 @@ gradient.
 ### 2.2 Parametrize `r` with a neural net
 
 We use a GPT-2 backbone (same architecture as Module 1) with one extra head on top —
-a single linear layer that outputs a scalar per position:
+a single linear layer that outputs a scalar per position. If $h_t$ is the final
+hidden state at position $t$, and $\ell$ is the index of the last non-padding token
+in the sequence, then:
+
+$$
+r(y) \;=\; w^\top h_\ell \,+\, b
+$$
+
+Or in code-style:
 
     r(y) = w @ h_final[last_real_token_index] + b
 
-where `h_final[t]` is the final layer's hidden state at position `t`, and
-`last_real_token_index` is the index of the last non-padding token in the sequence.
+$w$ is a vector of shape `(n_embd,)`, $b$ is a scalar, and the whole thing is just
+one `nn.Linear(n_embd, 1)` applied at one position.
 
 **Why the last position?** Because causal attention means the hidden at position `t`
 has only looked at positions `0, 1, ..., t`. Only the *last* position has seen the
@@ -76,26 +102,46 @@ judged the full response.
 
 ### 2.3 The loss
 
-For a single preference pair `(y_c, y_r)`, the loss is the negative log-probability
-(under the Bradley–Terry model) that the human would pick `y_c` — which, by
+For a single preference pair $(y_c, y_r)$, the loss is the negative log-probability
+(under the Bradley–Terry model) that the human would pick $y_c$ — which, by
 assumption, they did:
+
+$$
+L_{\mathrm{BT}} \;=\; -\log P(c \succ r) \;=\; -\log \sigma\bigl(r(y_c) - r(y_r)\bigr)
+$$
+
+Or in code-style:
 
     L_BT = -log P(c preferred over r)
          = -log sigmoid(r(y_c) - r(y_r))
 
 Average over the dataset. That's the whole loss.
 
+This is just **binary logistic regression** with a twist: the "input" is the
+difference between two full transformer forward passes instead of a flat feature
+vector. If you've ever written logistic regression for spam classification, you've
+seen this loss before.
+
 ---
 
 ## 3. The `softplus` form (numerical stability)
 
-Define `Delta = r(y_c) - r(y_r)`. Some algebra on the negative log-sigmoid:
+Define $\Delta = r(y_c) - r(y_r)$. A bit of algebra on the negative log-sigmoid:
 
-    -log sigmoid(Delta)
-    = -log( 1 / (1 + exp(-Delta)) )
-    =  log( 1 + exp(-Delta) )
+$$
+-\log \sigma(\Delta)
+\;=\; -\log\!\left(\frac{1}{1 + e^{-\Delta}}\right)
+\;=\; \log\bigl(1 + e^{-\Delta}\bigr)
+$$
 
-The function `softplus(x) = log(1 + exp(x))` is a standard numerically-stable op. So:
+The function $\mathrm{softplus}(x) = \log(1 + e^{x})$ is a standard
+numerically-stable op. So:
+
+$$
+L_{\mathrm{BT}} \;=\; \mathrm{softplus}(-\Delta) \;=\; \mathrm{softplus}\bigl(r(y_r) - r(y_c)\bigr)
+$$
+
+Or in code-style:
 
     L_BT = softplus(-Delta) = softplus(r(y_r) - r(y_c))
 
@@ -115,37 +161,76 @@ In code, always write `F.softplus(r_r - r_c)`. Never `-log(sigmoid(r_c - r_r))`.
 
 ## 4. Gradient derivation
 
-Let `Delta = r_c - r_r`. The loss is `L = -log sigmoid(Delta)`.
+Let $\Delta = r_c - r_r$. The loss is $L = -\log \sigma(\Delta)$.
 
 ### 4.1 Derivative of sigmoid
 
 A useful fact:
 
+$$
+\sigma'(x) \;=\; \sigma(x)\,\bigl(1 - \sigma(x)\bigr)
+$$
+
+Or in code-style:
+
     sigmoid'(x) = sigmoid(x) * (1 - sigmoid(x))
 
-Derive it once yourself by differentiating `1 / (1 + exp(-x))`.
+Derive it once yourself. Write $\sigma(x) = 1/(1+e^{-x}) = (1+e^{-x})^{-1}$, use the
+chain rule with $u = 1+e^{-x}$:
 
-### 4.2 Gradient with respect to `Delta`
+$$
+\sigma'(x) \;=\; -u^{-2} \cdot u'(x) \;=\; -(1+e^{-x})^{-2} \cdot (-e^{-x}) \;=\; \frac{e^{-x}}{(1+e^{-x})^2}
+$$
 
-    d L / d Delta  =  -sigmoid'(Delta) / sigmoid(Delta)
-                   =  -(1 - sigmoid(Delta))
-                   =  sigmoid(Delta) - 1
+Then notice that $e^{-x}/(1+e^{-x}) = 1 - \sigma(x)$, and what's left factors as
+$\sigma(x) \cdot (1 - \sigma(x))$. This "$p(1-p)$" shape is the same Bernoulli-like
+variance you see all over statistics — it's maximal at $x=0$ (where the coin flip is
+uncertain) and shrinks to zero at the extremes (where the outcome is almost certain).
 
-This sits in the interval `(-1, 0)` — it's always negative. That makes sense: the
-loss goes *down* when `Delta` goes up, so the gradient (pointing in the direction of
-loss increase) points the other way.
+### 4.2 Gradient with respect to $\Delta$
 
-### 4.3 Chain rule to `r_c` and `r_r`
+Use the chain rule: $\partial L / \partial \Delta$ is "how does $L$ depend on
+$\sigma(\Delta)$" times "how does $\sigma(\Delta)$ depend on $\Delta$".
 
-Since `Delta = r_c - r_r`:
+$$
+\frac{\partial L}{\partial \Delta}
+\;=\; \frac{\partial}{\partial \Delta}\bigl(-\log \sigma(\Delta)\bigr)
+\;=\; -\frac{\sigma'(\Delta)}{\sigma(\Delta)}
+\;=\; -\frac{\sigma(\Delta)(1-\sigma(\Delta))}{\sigma(\Delta)}
+\;=\; -\bigl(1 - \sigma(\Delta)\bigr)
+\;=\; \sigma(\Delta) - 1
+$$
 
-    d Delta / d r_c = +1
-    d Delta / d r_r = -1
+Or in code-style:
 
-So:
+    d L / d Delta  =  sigmoid(Delta) - 1
 
-    d L / d r_c  =  sigmoid(Delta) - 1
-    d L / d r_r  =  1 - sigmoid(Delta)
+This sits in the interval $(-1, 0)$ — it's always negative. That makes sense: the
+loss goes *down* when $\Delta$ goes up, so the gradient (which points in the direction
+of loss *increase*) points the other way.
+
+### 4.3 Chain rule to $r_c$ and $r_r$
+
+Since $\Delta = r_c - r_r$, the partials are trivial:
+
+$$
+\frac{\partial \Delta}{\partial r_c} \;=\; +1,
+\qquad
+\frac{\partial \Delta}{\partial r_r} \;=\; -1
+$$
+
+So by the chain rule:
+
+$$
+\frac{\partial L}{\partial r_c} \;=\; \sigma(\Delta) - 1,
+\qquad
+\frac{\partial L}{\partial r_r} \;=\; 1 - \sigma(\Delta)
+$$
+
+Or in code-style:
+
+    d L / d r_c = sigmoid(Delta) - 1
+    d L / d r_r = 1 - sigmoid(Delta)
 
 ### 4.4 Sanity checks on the gradient
 

--- a/notes/04-ppo-gae.md
+++ b/notes/04-ppo-gae.md
@@ -33,10 +33,17 @@ Our "environment" is one episode of assistant generation. Given a prompt `s_0`
 
 The objective is the expected total reward over a sampled trajectory:
 
+$$
+J(\theta) \;=\; \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\, \sum_t \gamma^t \, r_t \,\right]
+$$
+
+Or in code-style:
+
     J(theta) = E_{tau ~ pi_theta} [ sum_t gamma^t * r_t ]
 
-`gamma` is a discount factor in `[0, 1]`. For text RL we use `gamma = 1` — episodes
-are short, and we want credit assignment to flow across the entire response.
+$\gamma$ is a discount factor in $[0, 1]$. For text RL we use $\gamma = 1$ — episodes
+are short, and we want credit assignment to flow across the entire response without
+the exponential dampening that $\gamma < 1$ would give.
 
 ---
 
@@ -44,14 +51,27 @@ are short, and we want credit assignment to flow across the entire response.
 
 ### 2.1 What it says
 
-The gradient of the expected return, with respect to the policy parameters `theta`,
+The gradient of the expected return, with respect to the policy parameters $\theta$,
 can be written as:
+
+$$
+\nabla_\theta J \;=\; \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\, \sum_t \nabla_\theta \log \pi_\theta(a_t \mid s_t) \cdot \hat G_t \,\right]
+$$
+
+Or in code-style:
 
     grad J = E_{tau ~ pi_theta} [ sum_t grad log pi_theta(a_t | s_t) * G_hat_t ]
 
-where `G_hat_t` is any unbiased estimate of "the return from time `t` onward",
-meaning `E[ sum over k >= t of gamma^{k-t} * r_k ]`. The simplest choice is the
-Monte Carlo return — just the actual cumulative reward we observed from time `t`:
+where $\hat G_t$ is any unbiased estimate of "the return from time $t$ onward",
+i.e. any random variable whose expectation equals
+$\mathbb{E}\bigl[\sum_{k \ge t} \gamma^{k-t} r_k\bigr]$. The simplest choice is the
+Monte Carlo return — just the actual cumulative reward we observed from time $t$:
+
+$$
+\hat G_t \;=\; \sum_{k=t}^{T-1} \gamma^{k-t} \, r_k
+$$
+
+Or in code-style:
 
     G_hat_t = sum over k = t..T-1 of gamma^{k-t} * r_k
 
@@ -59,18 +79,58 @@ Monte Carlo return — just the actual cumulative reward we observed from time `
 
 Do the full derivation on paper at least once. Sketch:
 
-- `J(theta) = sum over trajectories tau of p_theta(tau) * R(tau)`, where `R(tau)`
-  is the total return of the trajectory.
-- Factor the trajectory probability:
-  `p_theta(tau) = P(s_0) * product_t pi_theta(a_t | s_t) * P(s_{t+1} | s_t, a_t)`.
-  Only the policy factors depend on `theta`.
-- Take `log` and then `grad`: `grad log p_theta(tau) = sum_t grad log pi_theta(a_t | s_t)`.
-  The transition probabilities and initial state drop out because they don't depend
-  on `theta`.
-- Use the log-derivative trick: `grad J = E[ grad log p_theta(tau) * R(tau) ]`.
-- Apply causality: action `a_t` can only affect rewards from time `t` onward. So
-  inside the sum over `t`, we can replace the total return `R(tau)` with just the
-  return-to-go `G_hat_t` without changing the expectation.
+**Step 1.** Write the objective as a sum (or integral) over trajectories:
+
+$$
+J(\theta) \;=\; \sum_\tau p_\theta(\tau) \cdot R(\tau)
+$$
+
+where $R(\tau) = \sum_t \gamma^t r_t$ is the total return of the trajectory.
+
+**Step 2.** Factor the trajectory probability:
+
+$$
+p_\theta(\tau) \;=\; P(s_0) \,\prod_t \pi_\theta(a_t \mid s_t) \cdot P(s_{t+1} \mid s_t, a_t)
+$$
+
+Only the policy factors depend on $\theta$. The initial state distribution and the
+transition dynamics are "the environment" and we don't control them.
+
+**Step 3.** The **log-derivative trick**. For any function $f(\theta)$:
+
+$$
+\nabla_\theta f \;=\; f \cdot \nabla_\theta \log f
+$$
+
+(just rearrange $\nabla \log f = \nabla f / f$). Apply this to $p_\theta(\tau)$:
+
+$$
+\nabla_\theta p_\theta(\tau) \;=\; p_\theta(\tau) \cdot \nabla_\theta \log p_\theta(\tau)
+$$
+
+**Step 4.** Take the gradient of $J$ and push it inside the sum:
+
+$$
+\nabla_\theta J \;=\; \sum_\tau \nabla_\theta p_\theta(\tau) \cdot R(\tau)
+\;=\; \sum_\tau p_\theta(\tau) \cdot \nabla_\theta \log p_\theta(\tau) \cdot R(\tau)
+\;=\; \mathbb{E}_\tau \!\left[\, \nabla_\theta \log p_\theta(\tau) \cdot R(\tau) \,\right]
+$$
+
+**Step 5.** Take $\log$ of the factored $p_\theta(\tau)$ and then the gradient:
+
+$$
+\nabla_\theta \log p_\theta(\tau) \;=\; \sum_t \nabla_\theta \log \pi_\theta(a_t \mid s_t)
+$$
+
+The $P(s_0)$ and transition terms drop out because they don't depend on $\theta$.
+
+**Step 6.** Apply causality. Action $a_t$ can only affect rewards from time $t$
+onward — the past is the past. That lets us replace $R(\tau)$ inside the sum with
+just the return-to-go $\hat G_t$ without changing the expectation. Done.
+
+Intuition for the end result: at each step, we nudge the model to make the action
+it took more (or less) likely, weighted by how good the future turned out to be.
+"Take what worked, do more of it" — gradient descent on trial and error.
 
 ### 2.3 What this means intuitively
 
@@ -91,35 +151,61 @@ without introducing bias is the whole game from here on.
 
 ## 3. Baselines and advantages
 
-Here's a nice fact. For any function `b(s_t)` that depends only on the state (not
+Here's a nice fact. For any function $b(s_t)$ that depends only on the state (not
 on the action we took):
 
-    E_{a ~ pi} [ grad log pi(a | s_t) * b(s_t) ]  =  0
+$$
+\mathbb{E}_{a \sim \pi}\!\left[\, \nabla_\theta \log \pi(a \mid s_t) \cdot b(s_t) \,\right] \;=\; 0
+$$
 
-Why? Because `b(s_t)` doesn't depend on `a`, so it pulls out of the expectation
-over `a`. What's left is `E_a[ grad log pi(a | s_t) ]`, which equals
-`grad E_a[ 1 ] = grad 1 = 0`.
+Why? Because $b(s_t)$ doesn't depend on $a$, it pulls out of the expectation over
+$a$. What's left is $\mathbb{E}_a[\nabla \log \pi(a \mid s_t)]$, which is zero.
+Here's the one-line proof of that inner identity:
 
-So we can *subtract* any state-dependent `b(s_t)` from our return estimate
+$$
+\mathbb{E}_a \bigl[\nabla \log \pi(a \mid s)\bigr]
+\;=\; \sum_a \pi(a \mid s) \cdot \frac{\nabla \pi(a \mid s)}{\pi(a \mid s)}
+\;=\; \sum_a \nabla \pi(a \mid s)
+\;=\; \nabla \sum_a \pi(a \mid s)
+\;=\; \nabla 1 \;=\; 0
+$$
+
+So we can **subtract** any state-dependent $b(s_t)$ from our return estimate
 without changing the expected gradient:
 
-    grad J  =  E[ sum_t grad log pi(a_t | s_t) * (G_hat_t - b(s_t)) ]
+$$
+\nabla_\theta J \;=\; \mathbb{E}\!\left[\, \sum_t \nabla_\theta \log \pi(a_t \mid s_t) \cdot \bigl(\hat G_t - b(s_t)\bigr) \,\right]
+$$
 
-This is unbiased for any choice of `b(s_t)`. But a good choice of `b` can slash
-the variance of the estimator. The best choice is `b(s_t) = E[G_t | s_t]` — the
-expected return starting from state `s_t` — because subtracting it leaves behind
-only the *action-specific* deviation from the average.
+Or in code-style:
 
-We learn such a `b` with a neural network and call it the **value function**
-`V(s_t)`. The difference between the observed return and the expected return is
+    grad J = E[ sum_t grad log pi(a_t | s_t) * (G_hat_t - b(s_t)) ]
+
+This is unbiased for any choice of $b(s_t)$. But a **good** choice of $b$ can slash
+the variance of the estimator. The best choice is $b(s_t) = \mathbb{E}[\hat G_t \mid s_t]$
+— the expected return starting from state $s_t$ — because subtracting it leaves
+behind only the *action-specific* deviation from the average.
+
+We learn such a $b$ with a neural network and call it the **value function**
+$V(s_t)$. The difference between the observed return and the expected return is
 called the **advantage**:
 
-    A_t = G_hat_t - V(s_t)
+$$
+A_t \;=\; \hat G_t \,-\, V(s_t)
+$$
 
 Read "advantage" literally: how much better (or worse) did this action turn out than
-what we expected before taking it?
+what we expected before taking it? An analogy: a golfer's handicap gives you the
+expected score. Your actual score minus your handicap is your "advantage" for that
+round — it tells you whether you played above or below expectation.
 
 The variance-reduced policy gradient:
+
+$$
+\nabla_\theta J \;=\; \mathbb{E}\!\left[\, \sum_t \nabla_\theta \log \pi(a_t \mid s_t) \cdot A_t \,\right]
+$$
+
+Or in code-style:
 
     grad J = E[ sum_t grad log pi(a_t | s_t) * A_t ]
 
@@ -132,11 +218,17 @@ gradient algorithm uses.
 
 Before we define GAE, one more building block: the **one-step TD error**.
 
-    delta_t  =  r_t + gamma * V(s_{t+1}) - V(s_t)
+$$
+\delta_t \;=\; r_t \,+\, \gamma \, V(s_{t+1}) \,-\, V(s_t)
+$$
+
+Or in code-style:
+
+    delta_t = r_t + gamma * V(s_{t+1}) - V(s_t)
 
 Read this as: "the reward I actually got, plus what the value function says is left
 to earn from the next state, minus what I had expected from this state". It's the
-part of the return at time `t` that wasn't predicted by the value function. (TD
+part of the return at time $t$ that wasn't predicted by the value function. (TD
 stands for "temporal difference".)
 
 We can build advantage estimators out of TD errors, and we can pick how many of
@@ -146,7 +238,13 @@ them to use:
 
 Use one TD error:
 
-    A_t^(0) = delta_t
+$$
+A_t^{(1)} \;=\; \delta_t
+$$
+
+Or in code-style:
+
+    A_t^(1) = delta_t
 
 - **Low variance**: depends on only one reward sample.
 - **High bias**: relies heavily on `V(s_{t+1})` being accurate. If `V` is wrong, so
@@ -156,6 +254,12 @@ Use one TD error:
 
 Sum rewards all the way to the episode end:
 
+$$
+A_t^{(\infty)} \;=\; \sum_{k=t}^{T-1} \gamma^{k-t} \, r_k \;-\; V(s_t)
+$$
+
+Or in code-style:
+
     A_t^(infinity) = sum over k = t..T-1 of gamma^{k-t} * r_k  -  V(s_t)
 
 - **Zero bias**: doesn't trust `V` at all except as the baseline at time `t`.
@@ -163,13 +267,27 @@ Sum rewards all the way to the episode end:
 
 ### 4.3 n-step in between
 
-You can also use `n` real rewards and then bootstrap:
+You can also use $n$ real rewards and then bootstrap with $V$:
 
-    A_t^(n) = r_t + gamma * r_{t+1} + ... + gamma^{n-1} * r_{t+n-1} + gamma^n * V(s_{t+n}) - V(s_t)
+$$
+A_t^{(n)}
+\;=\; r_t + \gamma\, r_{t+1} + \cdots + \gamma^{n-1}\, r_{t+n-1} + \gamma^n V(s_{t+n}) \,-\, V(s_t)
+$$
+
+An equivalent form in terms of TD errors:
+
+$$
+A_t^{(n)} \;=\; \sum_{k=0}^{n-1} \gamma^k \, \delta_{t+k}
+$$
+
+Or in code-style:
+
+    A_t^(n) = r_t + gamma*r_{t+1} + ... + gamma^{n-1}*r_{t+n-1} + gamma^n*V(s_{t+n}) - V(s_t)
             = sum over k = 0..n-1 of gamma^k * delta_{t+k}
 
 (The second line is a nice algebraic identity — check it by expanding the definition
-of `delta`. The intermediate `V` terms telescope.)
+of $\delta$. The intermediate $V$ terms telescope: the $+\gamma V(s_{t+1})$ from
+$\delta_t$ cancels the $-V(s_{t+1})$ from $\delta_{t+1}$, and so on.)
 
 As `n` grows, bias falls and variance rises. GAE gives us a single knob that slides
 smoothly between these choices.
@@ -180,12 +298,18 @@ smoothly between these choices.
 
 ### 5.1 Definition
 
-GAE is an exponentially weighted average of the n-step advantages for all `n >= 1`.
+GAE is an exponentially weighted average of the n-step advantages for all $n \ge 1$.
 In terms of TD errors:
 
-    A_t^GAE  =  sum over k = 0, 1, 2, ... of (gamma * lambda)^k * delta_{t+k}
+$$
+A_t^{\mathrm{GAE}} \;=\; \sum_{k=0}^{\infty} (\gamma \lambda)^k \, \delta_{t+k}
+$$
 
-The knob is `lambda` in `[0, 1]`:
+Or in code-style:
+
+    A_t^GAE = sum over k = 0, 1, 2, ... of (gamma * lambda)^k * delta_{t+k}
+
+The knob is $\lambda$ in $[0, 1]$:
 
 - `lambda = 0`: GAE collapses to one-step TD, `A_t = delta_t`. Low variance, high
   bias.
@@ -195,18 +319,30 @@ The knob is `lambda` in `[0, 1]`:
 
 ### 5.2 Deriving the recursion
 
-This is the clever trick. Split off the first term of the sum:
+This is the clever trick. Split off the first term of the sum, then factor out one
+$(\gamma \lambda)$ from the rest:
+
+$$
+A_t^{\mathrm{GAE}}
+\;=\; \delta_t \,+\, \sum_{k=1}^{\infty} (\gamma\lambda)^k \, \delta_{t+k}
+\;=\; \delta_t \,+\, (\gamma\lambda) \sum_{k=0}^{\infty} (\gamma\lambda)^k \, \delta_{t+1+k}
+\;=\; \delta_t \,+\, (\gamma\lambda) \, A_{t+1}^{\mathrm{GAE}}
+$$
+
+Or in code-style:
 
     A_t = delta_t + sum over k = 1, 2, ... of (gamma*lambda)^k * delta_{t+k}
         = delta_t + (gamma*lambda) * sum over k = 0, 1, ... of (gamma*lambda)^k * delta_{t+1+k}
         = delta_t + (gamma*lambda) * A_{t+1}
 
-So the GAE advantage satisfies:
+So the GAE advantage satisfies the one-line recursion:
 
-    A_t = delta_t + gamma * lambda * A_{t+1}
+$$
+A_t \;=\; \delta_t \,+\, \gamma\lambda \, A_{t+1}
+$$
 
-Boundary condition: at the terminal time `T`, the episode is over, so `V(s_T) = 0`
-by convention and `A_T = 0`.
+Boundary condition: at the terminal time $T$, the episode is over, so $V(s_T) = 0$
+by convention and $A_T = 0$.
 
 This recursion runs *backwards* through time, from `T-1` down to `0`, and that's
 how we compute it in code.
@@ -229,6 +365,12 @@ zeroed out.
 ### 5.4 Returns as value targets
 
 After computing advantages, the value head needs a regression target. We use:
+
+$$
+R_t \;=\; A_t \,+\, V_t
+$$
+
+Or in code-style:
 
     R_t = A_t + V_t
 
@@ -269,7 +411,13 @@ position.
 In classical RL, the environment hands you a reward at every step. For text we
 have to *construct* the per-token reward ourselves:
 
-    r_t  =  - beta * KL_t(pi_theta || pi_ref)     +     r_RM(y) * (t == last_response_token)
+$$
+r_t \;=\; -\beta \cdot \mathrm{KL}_t(\pi_\theta \,\|\, \pi_{\mathrm{ref}}) \;+\; r_{\mathrm{RM}}(y) \cdot \mathbf{1}[\,t = T_{\mathrm{last}}\,]
+$$
+
+Or in code-style:
+
+    r_t = -beta * KL_t(pi_theta || pi_ref)  +  r_RM(y) * (t == last_response_token)
 
 Two pieces:
 
@@ -299,6 +447,16 @@ Two consequences worth understanding:
 
 Before feeding advantages into the PPO policy loss, normalize them across valid
 tokens so they have mean 0 and std 1:
+
+$$
+\mu \;=\; \frac{\sum_{b,t} m_{b,t}\, A_{b,t}}{\sum_{b,t} m_{b,t}},
+\qquad
+\sigma^2 \;=\; \frac{\sum_{b,t} m_{b,t}\, (A_{b,t} - \mu)^2}{\sum_{b,t} m_{b,t}},
+\qquad
+\tilde A \;=\; \frac{A - \mu}{\sqrt{\sigma^2} + \varepsilon}
+$$
+
+Or in code-style:
 
     mean = (sum over (b, t) of mask[b, t] * A[b, t])  /  sum(mask)
     var  = (sum over (b, t) of mask[b, t] * (A[b, t] - mean)^2)  /  sum(mask)

--- a/notes/04-ppo-kl.md
+++ b/notes/04-ppo-kl.md
@@ -27,9 +27,16 @@ love. This failure mode is called **reward hacking**.
 The fix: penalize the policy for wandering too far from where it started (the SFT
 model), measured in KL divergence. The RL objective becomes:
 
-    J_RLHF(theta) = E [ r_RM(trajectory) - beta * sum over t of KL( pi_theta(. | s_t) || pi_ref(. | s_t) ) ]
+$$
+J_{\mathrm{RLHF}}(\theta)
+\;=\; \mathbb{E}\!\left[\, r_{\mathrm{RM}}(\tau) \;-\; \beta \sum_t \mathrm{KL}\bigl(\pi_\theta(\cdot \mid s_t) \,\|\, \pi_{\mathrm{ref}}(\cdot \mid s_t)\bigr) \,\right]
+$$
 
-`beta` controls the strength of the penalty:
+Or in code-style:
+
+    J_RLHF(theta) = E[ r_RM(tau) - beta * sum over t of KL(pi_theta(.|s_t) || pi_ref(.|s_t)) ]
+
+$\beta$ controls the strength of the penalty:
 
 - Small `beta`: policy is free to explore, but reward-hacking risk is high.
 - Large `beta`: policy stays close to SFT, but reward gains will be small.
@@ -53,6 +60,12 @@ Option A: compute a single KL per episode and tack it onto the final reward.
 Option B: distribute the KL penalty across tokens, one per step.
 
 InstructGPT picks option B. The per-token reward becomes:
+
+$$
+r_t \;=\; -\beta \cdot \mathrm{KL}_t \;+\; r_{\mathrm{RM}} \cdot \mathbf{1}[\,t = T_{\mathrm{last}}\,]
+$$
+
+Or in code-style:
 
     r_t = -beta * KL_t + r_RM * (t == last_response_token)
 
@@ -78,21 +91,41 @@ Here's the setup. During rollout, we generated a sequence of tokens from
 We want to estimate the KL divergence between the two policies *at that state*,
 defined as:
 
-    KL( pi_theta(. | s_t) || pi_ref(. | s_t) )
-      = E_{a ~ pi_theta} [ log pi_theta(a | s_t) - log pi_ref(a | s_t) ]
+$$
+\mathrm{KL}\bigl(\pi_\theta(\cdot \mid s_t) \,\|\, \pi_{\mathrm{ref}}(\cdot \mid s_t)\bigr)
+\;=\; \mathbb{E}_{a \sim \pi_\theta}\!\left[\, \log \pi_\theta(a \mid s_t) \,-\, \log \pi_{\mathrm{ref}}(a \mid s_t) \,\right]
+$$
 
-But we don't have access to the full distribution or an exact expectation. We have
-exactly one sample `a_t` drawn from `pi_theta`. What's our best single-sample
-estimate?
+Or in code-style:
+
+    KL(pi_theta(.|s_t) || pi_ref(.|s_t))
+      = E_{a ~ pi_theta}[ log pi_theta(a|s_t) - log pi_ref(a|s_t) ]
+
+But we don't have the full distribution or an exact expectation. We have exactly
+one sample $a_t$ drawn from $\pi_\theta$. What's our best single-sample estimate?
 
 Define the log-ratio for the token we drew:
 
-    L_t  =  log pi_theta(a_t | s_t) - log pi_ref(a_t | s_t)
+$$
+L_t \;=\; \log \pi_\theta(a_t \mid s_t) \,-\, \log \pi_{\mathrm{ref}}(a_t \mid s_t),
+\qquad
+\rho_t \;=\; e^{L_t}
+$$
+
+Or in code-style:
+
+    L_t   = log pi_theta(a_t | s_t) - log pi_ref(a_t | s_t)
     rho_t = exp(L_t)
 
-Three standard estimators, `k_1`, `k_2`, `k_3`:
+Three standard estimators, $k_1$, $k_2$, $k_3$:
 
-### 3.1 `k_1`: the naive log-ratio
+### 3.1 $k_1$: the naive log-ratio
+
+$$
+k_1 \;=\; L_t
+$$
+
+Or in code-style:
 
     k_1 = L_t
 
@@ -105,7 +138,13 @@ Three standard estimators, `k_1`, `k_2`, `k_3`:
 This is what InstructGPT uses as the shaping penalty in the per-token reward. It's
 exactly what we use in `shape_reward`.
 
-### 3.2 `k_2`: half-squared log-ratio
+### 3.2 $k_2$: half-squared log-ratio
+
+$$
+k_2 \;=\; \tfrac{1}{2} L_t^2
+$$
+
+Or in code-style:
 
     k_2 = 0.5 * L_t^2
 
@@ -115,16 +154,23 @@ exactly what we use in `shape_reward`.
   KL in general.
 - Rarely used in modern RLHF. Included here for completeness.
 
-### 3.3 `k_3`: Schulman's unbiased-and-nonnegative
+### 3.3 $k_3$: Schulman's unbiased-and-nonnegative
+
+$$
+k_3 \;=\; (\rho_t - 1) \,-\, L_t \;=\; e^{L_t} - 1 - L_t
+$$
+
+Or in code-style:
 
     k_3 = (rho_t - 1) - L_t
         = exp(L_t) - 1 - L_t
 
-- Always **non-negative**, because `exp(x) - 1 - x >= 0` for all real `x` (the
-  exponential function lies above its tangent at 0). Equality only when `x = 0`.
+- Always **non-negative**, because $e^x - 1 - x \ge 0$ for all real $x$ (the
+  exponential function lies above its tangent at 0, a direct consequence of
+  convexity of $e^x$). Equality only when $x = 0$.
 - **Unbiased** (with a caveat).
-- **Lower variance than `k_1`** in practice: when `k_1` has a big-magnitude
-  negative sample, `k_3` pulls it back up via the `rho - 1` term, and vice versa.
+- **Lower variance than $k_1$** in practice: when $k_1$ has a big-magnitude
+  negative sample, $k_3$ pulls it back up via the $\rho - 1$ term, and vice versa.
 
 A quick geometric picture: `k_1` is just the raw log-ratio of whatever token you
 happened to draw. `k_3` adds a symmetric correction penalizing any deviation of
@@ -161,9 +207,21 @@ Putting it all together. After a rollout we have:
 
 Compute the per-token KL:
 
+$$
+\mathrm{KL}_{k1}[b, t] \;=\; \log \pi_\theta^{\text{old}}(a_t \mid s_t) \,-\, \log \pi_{\mathrm{ref}}(a_t \mid s_t)
+$$
+
+Or in code-style:
+
     KL_k1[b, t] = logprobs_old[b, t] - ref_logprobs[b, t]
 
 And the per-token reward:
+
+$$
+r[b, t] \;=\; -\beta \cdot \mathrm{KL}_{k1}[b, t] \cdot m[b, t] \;+\; r_{\mathrm{RM}}[b] \cdot \mathbf{1}[\,t = T_{\mathrm{last}}(b)\,]
+$$
+
+Or in code-style:
 
     r[b, t] = -beta * KL_k1[b, t] * response_mask[b, t]
               + rm_reward[b] * (t == last_response_token_of_row_b)

--- a/notes/04-ppo-policy.md
+++ b/notes/04-ppo-policy.md
@@ -5,6 +5,12 @@
 Theory packet for Problems 4.5, 4.6, and 4.7. Derive and reason about the three
 terms that make up the PPO loss:
 
+$$
+L_{\mathrm{PPO}} \;=\; L_{\mathrm{policy}} \,+\, c_v \cdot L_{\mathrm{value}} \,-\, c_{\mathrm{ent}} \cdot H
+$$
+
+Or in code-style:
+
     L_PPO = L_policy + c_v * L_value - c_entropy * H
 
 By the end you should be able to:
@@ -21,6 +27,12 @@ By the end you should be able to:
 
 Recall from `04-ppo-gae.md` that the policy gradient with advantage baseline is:
 
+$$
+\nabla_\theta J \;=\; \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\, \sum_t \nabla_\theta \log \pi_\theta(a_t \mid s_t) \cdot A_t \,\right]
+$$
+
+Or in code-style:
+
     grad J = E_{tau ~ pi_theta} [ sum_t grad log pi_theta(a_t | s_t) * A_t ]
 
 **The problem.** To estimate this gradient, we need trajectories from the *current*
@@ -31,18 +43,29 @@ policy has been updated a few times, though, the rollouts are "off-policy" and t
 expectation is no longer correct for the new policy.
 
 **The fix.** Importance sampling. The rollouts come from a snapshot policy
-`pi_old`, frozen at the start of the current outer iteration. We rewrite the
-objective as an expectation under `pi_old` with an importance weight:
+$\pi_{\mathrm{old}}$, frozen at the start of the current outer iteration. We rewrite
+the objective as an expectation under $\pi_{\mathrm{old}}$ with an importance weight:
 
-    J(theta) = E_{tau ~ pi_old} [ sum_t rho_t(theta) * A_t ]
+$$
+J(\theta) \;=\; \mathbb{E}_{\tau \sim \pi_{\mathrm{old}}}\!\left[\, \sum_t \rho_t(\theta) \cdot A_t \,\right]
+$$
 
 where the **importance ratio** is:
 
-    rho_t(theta) = pi_theta(a_t | s_t) / pi_old(a_t | s_t)
-                 = exp( log pi_theta(a_t | s_t) - log pi_old(a_t | s_t) )
+$$
+\rho_t(\theta)
+\;=\; \frac{\pi_\theta(a_t \mid s_t)}{\pi_{\mathrm{old}}(a_t \mid s_t)}
+\;=\; \exp\!\bigl(\log \pi_\theta(a_t \mid s_t) \,-\, \log \pi_{\mathrm{old}}(a_t \mid s_t)\bigr)
+$$
 
-As long as `pi_theta` stays close to `pi_old`, the gradient of this rewritten
-expression equals the policy gradient.
+Or in code-style:
+
+    J(theta) = E_{tau ~ pi_old} [ sum_t rho_t(theta) * A_t ]
+    rho_t(theta) = pi_theta(a_t|s_t) / pi_old(a_t|s_t)
+                 = exp(log pi_theta(a_t|s_t) - log pi_old(a_t|s_t))
+
+As long as $\pi_\theta$ stays close to $\pi_{\mathrm{old}}$, the gradient of this
+rewritten expression equals the true policy gradient.
 
 **The catch.** If `pi_theta` drifts far from `pi_old`, the ratios `rho_t` can
 become enormous or tiny, and the gradient estimator explodes with variance. Every
@@ -57,18 +80,35 @@ the batch while preventing the policy from moving too far per update.
 
 For each token, define two candidate surrogates:
 
+$$
+\mathrm{surr}_1 \;=\; \rho \cdot A,
+\qquad
+\mathrm{surr}_2 \;=\; \mathrm{clip}(\rho,\, 1 - \varepsilon,\, 1 + \varepsilon) \cdot A
+$$
+
+where $\mathrm{clip}(x, \text{lo}, \text{hi})$ pins $x$ to the range
+$[\text{lo}, \text{hi}]$. $\varepsilon$ is typically 0.2.
+
+Or in code-style:
+
     surr1 = rho * A
     surr2 = clip(rho, 1 - epsilon, 1 + epsilon) * A
 
-where `clip(x, lo, hi)` pins `x` to the range `[lo, hi]`. `epsilon` is typically
-0.2.
-
 The PPO per-token loss is:
 
-    L_clip_t = - min(surr1, surr2)
+$$
+L_{\mathrm{clip},t} \;=\; -\min(\mathrm{surr}_1,\, \mathrm{surr}_2)
+$$
 
-And the total policy loss:
+And the total policy loss, normalized by the number of valid tokens:
 
+$$
+L_{\mathrm{policy}} \;=\; \frac{1}{N} \sum_{b,t} m_{b,t} \cdot L_{\mathrm{clip},t}
+$$
+
+Or in code-style:
+
+    L_clip_t = -min(surr1, surr2)
     L_policy = (1 / N) * sum over (b, t) of mask[b, t] * L_clip[b, t]
 
 where `N` is the count of masked-in response tokens.
@@ -103,20 +143,36 @@ back toward 1.
 
 ### 2.3 Deriving the piecewise gradient
 
-For the unclipped case, the per-token loss is `L = -rho * A`. Using
-`rho = exp(log pi_theta - log pi_old)`:
+For the unclipped case, the per-token loss is $L = -\rho A$. Using
+$\rho = \exp(\log \pi_\theta - \log \pi_{\mathrm{old}})$:
+
+$$
+\frac{\partial \rho}{\partial \log \pi_\theta} \;=\; \rho
+$$
+
+So by the chain rule:
+
+$$
+\frac{\partial L}{\partial \log \pi_\theta} \;=\; -A \cdot \rho
+$$
+
+Or in code-style:
 
     d rho / d log pi_theta = rho
-
-So:
-
     d L / d log pi_theta = -A * rho
 
-At `rho = 1` (on-policy limit), this simplifies to `-A`, which recovers the
+At $\rho = 1$ (on-policy limit), this simplifies to $-A$, which recovers the
 vanilla policy gradient direction.
 
-For the clipped case, `surr2 = (a constant with respect to theta) * A`. The
-clip saturates, so changing `log pi_theta` doesn't change `surr2`. Therefore:
+For the clipped case, $\mathrm{surr}_2 = (\text{constant w.r.t. } \theta) \cdot A$.
+The clip saturates, so changing $\log \pi_\theta$ doesn't change $\mathrm{surr}_2$.
+Therefore:
+
+$$
+\frac{\partial L}{\partial \log \pi_\theta} \;=\; 0
+$$
+
+Or in code-style:
 
     d L / d log pi_theta = 0
 
@@ -150,10 +206,22 @@ why everyone uses PPO.
 
 The value head's job is to regress toward the GAE return:
 
-    R_t = A_t + V_old(s_t)
+$$
+R_t \;=\; A_t \,+\, V_{\mathrm{old}}(s_t)
+$$
 
 which is computed at rollout time and treated as a constant during optimization
-(stop-gradient). The simplest value loss is plain MSE:
+(stop-gradient). Or in code-style:
+
+    R_t = A_t + V_old(s_t)
+
+The simplest value loss is plain MSE:
+
+$$
+L_{V,\mathrm{unclipped}} \;=\; \frac{1}{2N} \sum_{b,t} m_{b,t} \cdot \bigl(V_\theta(s_t) - R_t\bigr)^2
+$$
+
+Or in code-style:
 
     L_V_unclipped = (1 / (2*N)) * sum over (b, t) of mask[b, t] * (V_theta(s_t) - R_t)^2
 
@@ -163,10 +231,23 @@ Gradient is `mask * (V_theta - R) * dV_theta/dtheta` — standard MSE.
 
 The clipped value loss mirrors the policy clip. Define:
 
-    V_clipped(s_t) = V_old(s_t) + clip(V_theta(s_t) - V_old(s_t), -eps_v, +eps_v)
+$$
+V_{\mathrm{clipped}}(s_t) \;=\; V_{\mathrm{old}}(s_t) \,+\, \mathrm{clip}\bigl(V_\theta(s_t) - V_{\mathrm{old}}(s_t),\; -\varepsilon_v,\; +\varepsilon_v\bigr)
+$$
 
 Then:
 
+$$
+\mathrm{per\text{-}tok\, loss} \;=\; \tfrac{1}{2} \, \max\!\left((V_\theta - R)^2,\; (V_{\mathrm{clipped}} - R)^2\right)
+$$
+
+$$
+L_V \;=\; \frac{1}{N} \sum_{b,t} m_{b,t} \cdot \mathrm{per\text{-}tok\, loss}_{b,t}
+$$
+
+Or in code-style:
+
+    V_clipped(s_t) = V_old(s_t) + clip(V_theta(s_t) - V_old(s_t), -eps_v, +eps_v)
     per_tok_loss = 0.5 * max( (V_theta - R)^2, (V_clipped - R)^2 )
     L_V = (1 / N) * sum over (b, t) of mask[b, t] * per_tok_loss[b, t]
 
@@ -217,6 +298,12 @@ you'd compute by hand for the selected branch.
 
 Add the negated entropy of the policy to the loss:
 
+$$
+L_{\mathrm{total}} \;=\; L_{\mathrm{policy}} \,+\, c_v \cdot L_{\mathrm{value}} \,-\, c_{\mathrm{ent}} \cdot H(\pi_\theta)
+$$
+
+Or in code-style:
+
     L_total = L_policy + c_v * L_value - c_entropy * H(pi_theta)
 
 The negative sign means a gradient step *increases* entropy — rewarding the policy
@@ -230,39 +317,80 @@ near zero, generations getting repetitive), bump it to `0.01`.
 
 ### 4.2 Masked entropy
 
-For one position, the entropy of the per-token distribution `p` over the vocab is:
+For one position, the entropy of the per-token distribution $p$ over the vocab is:
 
-    H(p) = - sum over v of p[v] * log p[v]
+$$
+H(p) \;=\; -\sum_v p_v \, \log p_v
+$$
 
 For a batch of positions:
 
+$$
+H_{\mathrm{batch}} \;=\; \frac{1}{N} \sum_{b,t} m_{b,t} \cdot H(p_{b,t})
+$$
+
+Or in code-style:
+
+    H(p) = - sum over v of p[v] * log p[v]
     H_batch = (1 / N) * sum over (b, t) of mask[b, t] * H(p[b, t])
 
-### 4.3 Gradient of `H` with respect to logits
+### 4.3 Gradient of $H$ with respect to logits
 
-Let `z` be the logits and `p = softmax(z)`. Using the softmax derivative
-`d p[v] / d z[u] = p[v] * (delta(v, u) - p[u])` from `02-sft.md`:
+Let $z$ be the logits and $p = \mathrm{softmax}(z)$. Start from the definition:
+
+$$
+H \;=\; -\sum_v p_v \, \log p_v
+$$
+
+Differentiating $p_v \log p_v$ with respect to $z_u$ gives
+$(\partial p_v / \partial z_u) \cdot (\log p_v + 1)$ (product rule, using
+$\partial \log p_v / \partial p_v = 1/p_v$). So:
+
+$$
+\frac{\partial H}{\partial z_u}
+\;=\; -\sum_v \frac{\partial p_v}{\partial z_u} \cdot \bigl(\log p_v + 1\bigr)
+$$
+
+Now plug in the softmax derivative
+$\partial p_v / \partial z_u = p_v(\delta_{v,u} - p_u)$ from `02-sft.md`:
+
+$$
+\frac{\partial H}{\partial z_u}
+\;=\; -\sum_v p_v (\delta_{v,u} - p_u) \cdot (\log p_v + 1)
+$$
+
+Split the $(\delta_{v,u} - p_u)$ into the two pieces. The $\delta_{v,u}$ piece picks
+out only the $v = u$ term. The $-p_u$ piece factors out of the sum:
+
+$$
+\frac{\partial H}{\partial z_u}
+\;=\; -\,p_u (\log p_u + 1) \;+\; p_u \sum_v p_v (\log p_v + 1)
+$$
+
+The sum on the right equals $-H + 1$ (since $\sum_v p_v \log p_v = -H$ and
+$\sum_v p_v = 1$). Substitute:
+
+$$
+\frac{\partial H}{\partial z_u}
+\;=\; -p_u (\log p_u + 1) \,+\, p_u \cdot (-H + 1)
+\;=\; -p_u \,(\log p_u + H)
+$$
+
+In vector form:
+
+$$
+\nabla_z H \;=\; -p \,\odot\, (\log p + H)
+$$
+
+(elementwise product). Or in code-style:
 
     d H / d z[u]
     = - sum over v of (d p[v] / d z[u]) * (log p[v] + 1)
     = - sum over v of p[v] * (delta(v, u) - p[u]) * (log p[v] + 1)
-
-Expand:
-
-    = - p[u] * (log p[u] + 1)  +  p[u] * sum over v of p[v] * (log p[v] + 1)
-
-The sum on the right equals `-H + 1`, since `sum_v p[v] * log p[v] = -H` and
-`sum_v p[v] = 1`. So:
-
-    d H / d z[u]
-    = - p[u] * (log p[u] + 1)  +  p[u] * (-H + 1)
-    = - p[u] * (log p[u] + H)
-
-In vector form:
+    = - p[u] * (log p[u] + 1) + p[u] * sum over v of p[v] * (log p[v] + 1)
+    = - p[u] * (log p[u] + H)     # since sum_v p[v]*log p[v] = -H and sum_v p[v] = 1
 
     d H / d z  =  - p * (log p + H)
-
-(elementwise product).
 
 ### 4.4 Sanity check
 


### PR DESCRIPTION
## Summary
Enhanced the theory documentation by adding proper LaTeX mathematical notation alongside code-style equations. This improves readability and mathematical rigor while maintaining the existing code examples for practical reference.

## Key Changes

- **Added LaTeX equations** throughout all theory notes (`01-gpt2.md`, `02-sft.md`, `03-rm.md`, `04-ppo-gae.md`, `04-ppo-policy.md`, `04-ppo-kl.md`) using `$$..$$` delimiters for display math
- **Improved mathematical notation** by replacing inline code-style variables with proper mathematical symbols (e.g., `theta` → $\theta$, `pi_theta` → $\pi_\theta$, `gamma` → $\gamma$)
- **Structured equations** with consistent formatting: LaTeX equation first, followed by "Or in code-style:" and the code version
- **Enhanced derivations** in `04-ppo-gae.md` with step-by-step numbered sections and clearer mathematical exposition
- **Added intuitive explanations** for key concepts (e.g., golfer handicap analogy for advantages, bucket water analogy for softmax gradient)
- **Improved clarity** in gradient derivations by showing intermediate steps and algebraic manipulations more explicitly
- **Standardized notation** across all documents (e.g., consistent use of $\mathbb{E}$ for expectations, $\nabla$ for gradients)

## Notable Implementation Details

- Maintained dual representation: formal mathematics for theoretical understanding + code-style for implementation reference
- Used consistent mathematical notation conventions (bold for vectors, subscripts for indexing, $\odot$ for element-wise operations)
- Added detailed proofs and derivations (e.g., softmax derivative, policy gradient theorem, GAE recursion)
- Improved numerical stability discussions with proper mathematical justification
- Enhanced readability of complex formulas by breaking them into logical steps with explanatory text

https://claude.ai/code/session_01FzV9R99yDbnYDuarjxGGk3