### PR TITLE
Standardize LaTeX formatting and add pedagogical content to notes

### DIFF
--- a/notes/01-gpt2.md
+++ b/notes/01-gpt2.md
@@ -78,7 +78,7 @@ GPT-2 has two learned lookup tables:
 The first layer of the model is just:
 
 $$
-h_0[b, t] \;=\; \mathrm{wte}\bigl[\mathrm{input\_ids}[b, t]\bigr] \,+\, \mathrm{wpe}[t]
+h_0[b, t] = \mathrm{wte}\bigl[\mathrm{input\_ids}[b, t]\bigr] + \mathrm{wpe}[t]
 $$
 
 Or in code-style:
@@ -105,15 +105,15 @@ position and normalize *within* it. We do not mix across batch or across time.
 Here's what it does, in equations. For a single token's hidden vector $x \in \mathbb{R}^C$:
 
 $$
-\mu \;=\; \frac{1}{C} \sum_{i=1}^{C} x_i,
+\mu = \frac{1}{C} \sum_{i=1}^{C} x_i,
 \qquad
-\sigma^2 \;=\; \frac{1}{C} \sum_{i=1}^{C} (x_i - \mu)^2
+\sigma^2 = \frac{1}{C} \sum_{i=1}^{C} (x_i - \mu)^2
 $$
 
 $$
-\hat x_i \;=\; \frac{x_i - \mu}{\sqrt{\sigma^2 + \varepsilon}},
+\hat x_i = \frac{x_i - \mu}{\sqrt{\sigma^2 + \varepsilon}},
 \qquad
-y_i \;=\; \gamma_i \cdot \hat x_i \,+\, \beta_i
+y_i = \gamma_i \cdot \hat x_i + \beta_i
 $$
 
 In words, four steps:
@@ -182,7 +182,7 @@ represent?), and a "value" (what information do I carry?).
 For a single head, compute the dot product of every query with every key:
 
 $$
-S_{t, s} \;=\; \frac{Q_t \cdot K_s}{\sqrt{d_h}}
+S_{t, s} = \frac{Q_t \cdot K_s}{\sqrt{d_h}}
 $$
 
 Or in code-style:
@@ -208,7 +208,7 @@ performance.
 Apply softmax along the "keys" axis (the `s` dimension):
 
 $$
-\alpha_{t, s} \;=\; \frac{\exp(S_{t, s})}{\sum_{s'} \exp(S_{t, s'})}
+\alpha_{t, s} = \frac{\exp(S_{t, s})}{\sum_{s'} \exp(S_{t, s'})}
 $$
 
 Or in code-style:
@@ -223,7 +223,7 @@ probability distribution over "which earlier positions to attend to".
 For each position `t`, mix the value vectors using `alpha` as the weights:
 
 $$
-o_t \;=\; \sum_s \alpha_{t, s} \cdot V_s
+o_t = \sum_s \alpha_{t, s} \cdot V_s
 $$
 
 Or in code-style:
@@ -287,7 +287,7 @@ The exact definition uses the standard normal CDF $\Phi$ (the probability that a
 standard normal is less than $x$):
 
 $$
-\mathrm{GELU}(x) \;=\; x \cdot \Phi(x)
+\mathrm{GELU}(x) = x \cdot \Phi(x)
 $$
 
 Or in code-style:
@@ -446,7 +446,7 @@ you'll implement.
 Before softmax, divide logits by $\tau$:
 
 $$
-p_v \;=\; \frac{\exp(z_v / \tau)}{\sum_{v'} \exp(z_{v'} / \tau)}
+p_v = \frac{\exp(z_v / \tau)}{\sum_{v'} \exp(z_{v'} / \tau)}
 $$
 
 Or in code-style:

--- a/notes/02-sft.md
+++ b/notes/02-sft.md
@@ -271,7 +271,45 @@ water from every bucket in proportion to how full it is, then dump an equal tota
 amount into bucket $y$." After many steps, bucket $y$ is full and everything else
 is nearly empty — which is exactly what confident, correct prediction looks like.
 
-### 4.4 With the mask
+### 4.4 A worked example with numbers
+
+Let's make this concrete. Pretend our vocabulary has only 3 tokens, call them
+"cat", "dog", "fish" (indices 0, 1, 2). The true next token is "dog" (so $y = 1$).
+Suppose the model's raw logits are $z = (1.0,\, 2.0,\, 0.5)$.
+
+Step 1: softmax. Exponentiate each entry and divide by the sum:
+
+- $\exp(1.0) \approx 2.72$
+- $\exp(2.0) \approx 7.39$
+- $\exp(0.5) \approx 1.65$
+- Sum $\approx 11.76$
+- $p \approx (0.231,\, 0.628,\, 0.140)$
+
+So the model already thinks "dog" is most likely (62.8%), but it's not fully
+confident.
+
+Step 2: the loss. $\ell = -\log p_y = -\log(0.628) \approx 0.465$.
+
+Step 3: the gradient. Use the formula $\partial \ell / \partial z = p - e_y$,
+where $e_y = (0, 1, 0)$ is the one-hot vector at index 1:
+
+- $\partial \ell / \partial z_0 = 0.231 - 0 = +0.231$
+- $\partial \ell / \partial z_1 = 0.628 - 1 = -0.372$
+- $\partial \ell / \partial z_2 = 0.140 - 0 = +0.140$
+
+A gradient descent step moves $z$ in the *opposite* direction of the gradient (with
+some learning rate $\eta$), so after one step with $\eta = 1.0$:
+
+- $z_0 \leftarrow 1.0 - 0.231 = 0.769$ (cat logit went down — good, cat is wrong)
+- $z_1 \leftarrow 2.0 - (-0.372) = 2.372$ (dog logit went up — good, dog is right)
+- $z_2 \leftarrow 0.5 - 0.140 = 0.360$ (fish logit went down — good, fish is wrong)
+
+Recompute softmax with the new logits: $p \approx (0.154,\, 0.751,\, 0.095)$. The
+model is now 75% sure about "dog", up from 63%. One gradient step moved us in the
+right direction, and the gradient told us *exactly how much* to move each logit.
+Do this for 100 million tokens and you've got a trained language model.
+
+### 4.5 With the mask
 
 Across positions `t`, with the mask factored in:
 

--- a/notes/02-sft.md
+++ b/notes/02-sft.md
@@ -63,7 +63,7 @@ At each position `t`, the model outputs a logit vector $z_t$ of length `V` (voca
 size). Softmax converts logits to a probability distribution over the vocabulary:
 
 $$
-p_{t,v} \;=\; \frac{\exp(z_{t,v})}{\sum_{v'} \exp(z_{t,v'})}
+p_{t,v} = \frac{\exp(z_{t,v})}{\sum_{v'} \exp(z_{t,v'})}
 $$
 
 Or in code-style:
@@ -80,7 +80,7 @@ The cross-entropy loss at position `t` is the negative log-probability the model
 assigns to the true next token $y_t = \text{labels}[t]$:
 
 $$
-\ell_t \;=\; -\log p_{t,y_t} \;=\; -z_{t,y_t} \;+\; \log \sum_{v'} \exp(z_{t,v'})
+\ell_t = -\log p_{t,y_t} = -z_{t,y_t} + \log \sum_{v'} \exp(z_{t,v'})
 $$
 
 Or in code-style:
@@ -103,9 +103,9 @@ want it to produce.
 Summing across a batch of examples, indexed by `(b, t)`:
 
 $$
-L_{\mathrm{SFT}} \;=\; \frac{1}{N_{\mathrm{resp}}} \sum_{b, t} m_{b,t} \cdot \ell_{b,t},
+L_{\mathrm{SFT}} = \frac{1}{N_{\mathrm{resp}}} \sum_{b, t} m_{b,t} \cdot \ell_{b,t},
 \qquad
-N_{\mathrm{resp}} \;=\; \sum_{b, t} m_{b,t}
+N_{\mathrm{resp}} = \sum_{b, t} m_{b,t}
 $$
 
 Or in code-style:
@@ -172,7 +172,7 @@ the softmax of $z$. Let $y$ be the index of the correct class. The loss at this
 position is:
 
 $$
-\ell \;=\; -\log p_y
+\ell = -\log p_y
 $$
 
 We want $\partial \ell / \partial z$ — the gradient of the loss with respect to the
@@ -185,7 +185,7 @@ probability changes with the logit.
 For any two indices $v$ and $u$ we have:
 
 $$
-\frac{\partial p_v}{\partial z_u} \;=\; p_v \cdot (\delta_{v,u} \,-\, p_u)
+\frac{\partial p_v}{\partial z_u} = p_v \cdot (\delta_{v,u} - p_u)
 $$
 
 where $\delta_{v,u}$ is the Kronecker delta (reads: "1 if the subscripts are equal,
@@ -198,7 +198,7 @@ $S = \sum_{v'} \exp(z_{v'})$, and use the quotient rule:
 
 $$
 \frac{\partial p_v}{\partial z_u}
-\;=\; \frac{(\partial \exp(z_v)/\partial z_u) \cdot S \,-\, \exp(z_v) \cdot (\partial S/\partial z_u)}{S^2}
+ = \frac{(\partial \exp(z_v)/\partial z_u) \cdot S - \exp(z_v) \cdot (\partial S/\partial z_u)}{S^2}
 $$
 
 The first derivative in the numerator is $\exp(z_v) \cdot \delta_{v,u}$ (since
@@ -207,9 +207,9 @@ $\partial S/\partial z_u = \exp(z_u)$. Plug in and collect terms:
 
 $$
 \frac{\partial p_v}{\partial z_u}
-\;=\; \frac{\exp(z_v)}{S} \delta_{v,u} \;-\; \frac{\exp(z_v)}{S} \cdot \frac{\exp(z_u)}{S}
-\;=\; p_v \delta_{v,u} \;-\; p_v p_u
-\;=\; p_v (\delta_{v,u} - p_u)
+ = \frac{\exp(z_v)}{S} \delta_{v,u} - \frac{\exp(z_v)}{S} \cdot \frac{\exp(z_u)}{S}
+ = p_v \delta_{v,u} - p_v p_u
+ = p_v (\delta_{v,u} - p_u)
 $$
 
 Done. This result is worth memorizing — it shows up every time you differentiate a
@@ -222,34 +222,34 @@ $z_u$":
 
 $$
 \frac{\partial \ell}{\partial z_u}
-\;=\; \frac{\partial \ell}{\partial p_y} \cdot \frac{\partial p_y}{\partial z_u}
+ = \frac{\partial \ell}{\partial p_y} \cdot \frac{\partial p_y}{\partial z_u}
 $$
 
 The first factor comes from $\ell = -\log p_y$:
 
 $$
-\frac{\partial \ell}{\partial p_y} \;=\; -\frac{1}{p_y}
+\frac{\partial \ell}{\partial p_y} = -\frac{1}{p_y}
 $$
 
 The second factor we just computed (plug $v = y$):
 
 $$
-\frac{\partial p_y}{\partial z_u} \;=\; p_y (\delta_{y,u} - p_u)
+\frac{\partial p_y}{\partial z_u} = p_y (\delta_{y,u} - p_u)
 $$
 
 Multiply them:
 
 $$
 \frac{\partial \ell}{\partial z_u}
-\;=\; -\frac{1}{p_y} \cdot p_y (\delta_{y,u} - p_u)
-\;=\; -(\delta_{y,u} - p_u)
-\;=\; p_u - \delta_{y,u}
+ = -\frac{1}{p_y} \cdot p_y (\delta_{y,u} - p_u)
+ = -(\delta_{y,u} - p_u)
+ = p_u - \delta_{y,u}
 $$
 
 The $p_y$ cancels beautifully. In vector form:
 
 $$
-\frac{\partial \ell}{\partial z} \;=\; p \,-\, e_y
+\frac{\partial \ell}{\partial z} = p - e_y
 $$
 
 where $e_y$ is the one-hot vector with a 1 at index $y$ and 0 elsewhere. Or in
@@ -277,7 +277,7 @@ Across positions `t`, with the mask factored in:
 
 $$
 \frac{\partial L_{\mathrm{SFT}}}{\partial z_t}
-\;=\; \frac{m_t}{N_{\mathrm{resp}}} \cdot (p_t - e_{y_t})
+ = \frac{m_t}{N_{\mathrm{resp}}} \cdot (p_t - e_{y_t})
 $$
 
 Or in code-style:

--- a/notes/03-rm.md
+++ b/notes/03-rm.md
@@ -249,6 +249,39 @@ Or in code-style:
 This is just logistic regression. The only twist is that the "inputs" are two giant
 transformer forward passes.
 
+### 4.5 A worked example with numbers
+
+Let's put numbers to it. Say the RM currently outputs $r_c = 2.0$ and $r_r = 0.5$
+on some preference pair. Then $\Delta = 1.5$, $\sigma(1.5) \approx 0.818$, so the
+model thinks the chosen one wins about 82% of the time. The loss is
+$-\log(0.818) \approx 0.201$ — small but not zero.
+
+The gradients:
+
+- $\partial L / \partial r_c = \sigma(1.5) - 1 \approx -0.182$
+- $\partial L / \partial r_r = 1 - \sigma(1.5) \approx +0.182$
+
+Gradient descent moves in the *opposite* direction, so with learning rate
+$\eta = 1$ we get:
+
+- $r_c \leftarrow 2.0 - (-0.182) = 2.182$ (chosen score goes up a bit)
+- $r_r \leftarrow 0.5 - (+0.182) = 0.318$ (rejected score goes down a bit)
+
+After the step, $\Delta \approx 1.864$, $\sigma(\Delta) \approx 0.866$, loss drops
+to $\approx 0.144$. As the model becomes more confident, the gradient shrinks — the
+loss is self-regulating.
+
+Now consider the confidently-wrong case: $r_c = -1.0$, $r_r = +1.0$. Then
+$\Delta = -2.0$, $\sigma(-2.0) \approx 0.119$, loss $\approx 2.13$ — much bigger.
+The gradients:
+
+- $\partial L / \partial r_c \approx -0.881$ (big push on $r_c$ upward)
+- $\partial L / \partial r_r \approx +0.881$ (big push on $r_r$ downward)
+
+Both are close to $\pm 1$, the maximum possible signal. That's the pattern of
+logistic regression: when you're right, small updates; when you're wrong, big
+updates. Everything is automatic once you write down the loss.
+
 ---
 
 ## 5. Architecture details (Problem 3.1)

--- a/notes/03-rm.md
+++ b/notes/03-rm.md
@@ -26,7 +26,7 @@ such that, on average, the chosen completion gets a higher score than the reject
 one:
 
 $$
-\mathbb{E}\,[\, r(y_c) \,-\, r(y_r) \,] \;>\; 0
+\mathbb{E} [ r(y_c) - r(y_r) ] > 0
 $$
 
 Or in code-style:
@@ -49,13 +49,13 @@ do it *noisily* — sometimes they pick the worse one, more often when the two a
 close in quality. Specifically, Bradley–Terry assumes:
 
 $$
-P(\text{human picks } y_c \text{ over } y_r) \;=\; \sigma\bigl(r(y_c) - r(y_r)\bigr)
+P(\text{human picks } y_c \text{ over } y_r) = \sigma\bigl(r(y_c) - r(y_r)\bigr)
 $$
 
 where $\sigma$ is the logistic sigmoid,
 
 $$
-\sigma(x) \;=\; \frac{1}{1 + e^{-x}}
+\sigma(x) = \frac{1}{1 + e^{-x}}
 $$
 
 Or in code-style:
@@ -85,7 +85,7 @@ hidden state at position $t$, and $\ell$ is the index of the last non-padding to
 in the sequence, then:
 
 $$
-r(y) \;=\; w^\top h_\ell \,+\, b
+r(y)  =  w^\top h_\ell  +  b
 $$
 
 Or in code-style:
@@ -107,7 +107,7 @@ For a single preference pair $(y_c, y_r)$, the loss is the negative log-probabil
 assumption, they did:
 
 $$
-L_{\mathrm{BT}} \;=\; -\log P(c \succ r) \;=\; -\log \sigma\bigl(r(y_c) - r(y_r)\bigr)
+L_{\mathrm{BT}} = -\log P(c \succ r) = -\log \sigma\bigl(r(y_c) - r(y_r)\bigr)
 $$
 
 Or in code-style:
@@ -130,15 +130,15 @@ Define $\Delta = r(y_c) - r(y_r)$. A bit of algebra on the negative log-sigmoid:
 
 $$
 -\log \sigma(\Delta)
-\;=\; -\log\!\left(\frac{1}{1 + e^{-\Delta}}\right)
-\;=\; \log\bigl(1 + e^{-\Delta}\bigr)
+ = -\log\left(\frac{1}{1 + e^{-\Delta}}\right)
+ = \log\bigl(1 + e^{-\Delta}\bigr)
 $$
 
 The function $\mathrm{softplus}(x) = \log(1 + e^{x})$ is a standard
 numerically-stable op. So:
 
 $$
-L_{\mathrm{BT}} \;=\; \mathrm{softplus}(-\Delta) \;=\; \mathrm{softplus}\bigl(r(y_r) - r(y_c)\bigr)
+L_{\mathrm{BT}} = \mathrm{softplus}(-\Delta) = \mathrm{softplus}\bigl(r(y_r) - r(y_c)\bigr)
 $$
 
 Or in code-style:
@@ -168,7 +168,7 @@ Let $\Delta = r_c - r_r$. The loss is $L = -\log \sigma(\Delta)$.
 A useful fact:
 
 $$
-\sigma'(x) \;=\; \sigma(x)\,\bigl(1 - \sigma(x)\bigr)
+\sigma'(x) = \sigma(x) \bigl(1 - \sigma(x)\bigr)
 $$
 
 Or in code-style:
@@ -179,7 +179,7 @@ Derive it once yourself. Write $\sigma(x) = 1/(1+e^{-x}) = (1+e^{-x})^{-1}$, use
 chain rule with $u = 1+e^{-x}$:
 
 $$
-\sigma'(x) \;=\; -u^{-2} \cdot u'(x) \;=\; -(1+e^{-x})^{-2} \cdot (-e^{-x}) \;=\; \frac{e^{-x}}{(1+e^{-x})^2}
+\sigma'(x) = -u^{-2} \cdot u'(x) = -(1+e^{-x})^{-2} \cdot (-e^{-x}) = \frac{e^{-x}}{(1+e^{-x})^2}
 $$
 
 Then notice that $e^{-x}/(1+e^{-x}) = 1 - \sigma(x)$, and what's left factors as
@@ -194,11 +194,11 @@ $\sigma(\Delta)$" times "how does $\sigma(\Delta)$ depend on $\Delta$".
 
 $$
 \frac{\partial L}{\partial \Delta}
-\;=\; \frac{\partial}{\partial \Delta}\bigl(-\log \sigma(\Delta)\bigr)
-\;=\; -\frac{\sigma'(\Delta)}{\sigma(\Delta)}
-\;=\; -\frac{\sigma(\Delta)(1-\sigma(\Delta))}{\sigma(\Delta)}
-\;=\; -\bigl(1 - \sigma(\Delta)\bigr)
-\;=\; \sigma(\Delta) - 1
+ = \frac{\partial}{\partial \Delta}\bigl(-\log \sigma(\Delta)\bigr)
+ = -\frac{\sigma'(\Delta)}{\sigma(\Delta)}
+ = -\frac{\sigma(\Delta)(1-\sigma(\Delta))}{\sigma(\Delta)}
+ = -\bigl(1 - \sigma(\Delta)\bigr)
+ = \sigma(\Delta) - 1
 $$
 
 Or in code-style:
@@ -214,17 +214,17 @@ of loss *increase*) points the other way.
 Since $\Delta = r_c - r_r$, the partials are trivial:
 
 $$
-\frac{\partial \Delta}{\partial r_c} \;=\; +1,
+\frac{\partial \Delta}{\partial r_c} = +1,
 \qquad
-\frac{\partial \Delta}{\partial r_r} \;=\; -1
+\frac{\partial \Delta}{\partial r_r} = -1
 $$
 
 So by the chain rule:
 
 $$
-\frac{\partial L}{\partial r_c} \;=\; \sigma(\Delta) - 1,
+\frac{\partial L}{\partial r_c} = \sigma(\Delta) - 1,
 \qquad
-\frac{\partial L}{\partial r_r} \;=\; 1 - \sigma(\Delta)
+\frac{\partial L}{\partial r_r} = 1 - \sigma(\Delta)
 $$
 
 Or in code-style:

--- a/notes/04-ppo-gae.md
+++ b/notes/04-ppo-gae.md
@@ -45,6 +45,33 @@ $\gamma$ is a discount factor in $[0, 1]$. For text RL we use $\gamma = 1$ — e
 are short, and we want credit assignment to flow across the entire response without
 the exponential dampening that $\gamma < 1$ would give.
 
+### 1.1 A concrete rollout
+
+If this is your first time meeting RL, the abstractions above can feel slippery.
+Make it concrete. Suppose the prompt is:
+
+    s_0 = "<|im_start|>user\nWhat is 2+2?<|im_end|>\n<|im_start|>assistant\n"
+
+The model generates, one token at a time:
+
+| $t$ | State $s_t$                                    | Action $a_t$ (sampled) | Reward $r_t$            |
+|-----|------------------------------------------------|------------------------|-------------------------|
+| 0   | prompt                                         | `"The"`                | small KL penalty only   |
+| 1   | prompt + `"The"`                               | `" answer"`            | small KL penalty only   |
+| 2   | prompt + `"The answer"`                        | `" is"`                | small KL penalty only   |
+| 3   | prompt + `"The answer is"`                     | `" 4"`                 | small KL penalty only   |
+| 4   | prompt + `"The answer is 4"`                   | `"."`                  | small KL penalty only   |
+| 5   | prompt + `"The answer is 4."`                  | `<|im_end|>`           | KL penalty + RM reward  |
+
+Each "state" is the entire token sequence so far. Each "action" is the next
+token the policy samples. Each "reward" is a scalar we compute per token — most
+are just tiny KL penalties, but the last one also carries the big terminal reward
+from the RM (its scalar opinion of the whole response).
+
+That's one rollout. An iteration of PPO generates a batch of many such rollouts
+in parallel. Every quantity in the rest of this note is defined on these
+per-token tuples $(s_t, a_t, r_t)$.
+
 ---
 
 ## 2. The policy gradient theorem
@@ -96,13 +123,20 @@ $$
 Only the policy factors depend on $\theta$. The initial state distribution and the
 transition dynamics are "the environment" and we don't control them.
 
-**Step 3.** The **log-derivative trick**. For any function $f(\theta)$:
+**Step 3.** The **log-derivative trick**. For any positive function $f(\theta)$:
 
 $$
 \nabla_\theta f = f \cdot \nabla_\theta \log f
 $$
 
-(just rearrange $\nabla \log f = \nabla f / f$). Apply this to $p_\theta(\tau)$:
+This is just the chain rule for $\log$: $\nabla_\theta \log f = (1/f) \cdot
+\nabla_\theta f$, so multiply both sides by $f$. The reason we use this trick:
+we want gradients to appear as expectations (sums of $f \cdot \text{something}$)
+so we can estimate them by averaging over samples. The log-derivative trick is
+the standard move for converting "gradient of a probability" into "probability
+times gradient of log-probability".
+
+Apply it to $p_\theta(\tau)$:
 
 $$
 \nabla_\theta p_\theta(\tau) = p_\theta(\tau) \cdot \nabla_\theta \log p_\theta(\tau)

--- a/notes/04-ppo-gae.md
+++ b/notes/04-ppo-gae.md
@@ -34,7 +34,7 @@ Our "environment" is one episode of assistant generation. Given a prompt `s_0`
 The objective is the expected total reward over a sampled trajectory:
 
 $$
-J(\theta) \;=\; \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\, \sum_t \gamma^t \, r_t \,\right]
+J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}\left[ \sum_t \gamma^t r_t \right]
 $$
 
 Or in code-style:
@@ -55,7 +55,7 @@ The gradient of the expected return, with respect to the policy parameters $\the
 can be written as:
 
 $$
-\nabla_\theta J \;=\; \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\, \sum_t \nabla_\theta \log \pi_\theta(a_t \mid s_t) \cdot \hat G_t \,\right]
+\nabla_\theta J = \mathbb{E}_{\tau \sim \pi_\theta}\left[ \sum_t \nabla_\theta \log \pi_\theta(a_t \mid s_t) \cdot \hat G_t \right]
 $$
 
 Or in code-style:
@@ -68,7 +68,7 @@ $\mathbb{E}\bigl[\sum_{k \ge t} \gamma^{k-t} r_k\bigr]$. The simplest choice is 
 Monte Carlo return — just the actual cumulative reward we observed from time $t$:
 
 $$
-\hat G_t \;=\; \sum_{k=t}^{T-1} \gamma^{k-t} \, r_k
+\hat G_t = \sum_{k=t}^{T-1} \gamma^{k-t} r_k
 $$
 
 Or in code-style:
@@ -82,7 +82,7 @@ Do the full derivation on paper at least once. Sketch:
 **Step 1.** Write the objective as a sum (or integral) over trajectories:
 
 $$
-J(\theta) \;=\; \sum_\tau p_\theta(\tau) \cdot R(\tau)
+J(\theta) = \sum_\tau p_\theta(\tau) \cdot R(\tau)
 $$
 
 where $R(\tau) = \sum_t \gamma^t r_t$ is the total return of the trajectory.
@@ -90,7 +90,7 @@ where $R(\tau) = \sum_t \gamma^t r_t$ is the total return of the trajectory.
 **Step 2.** Factor the trajectory probability:
 
 $$
-p_\theta(\tau) \;=\; P(s_0) \,\prod_t \pi_\theta(a_t \mid s_t) \cdot P(s_{t+1} \mid s_t, a_t)
+p_\theta(\tau) = P(s_0) \prod_t \pi_\theta(a_t \mid s_t) \cdot P(s_{t+1} \mid s_t, a_t)
 $$
 
 Only the policy factors depend on $\theta$. The initial state distribution and the
@@ -99,27 +99,27 @@ transition dynamics are "the environment" and we don't control them.
 **Step 3.** The **log-derivative trick**. For any function $f(\theta)$:
 
 $$
-\nabla_\theta f \;=\; f \cdot \nabla_\theta \log f
+\nabla_\theta f = f \cdot \nabla_\theta \log f
 $$
 
 (just rearrange $\nabla \log f = \nabla f / f$). Apply this to $p_\theta(\tau)$:
 
 $$
-\nabla_\theta p_\theta(\tau) \;=\; p_\theta(\tau) \cdot \nabla_\theta \log p_\theta(\tau)
+\nabla_\theta p_\theta(\tau) = p_\theta(\tau) \cdot \nabla_\theta \log p_\theta(\tau)
 $$
 
 **Step 4.** Take the gradient of $J$ and push it inside the sum:
 
 $$
-\nabla_\theta J \;=\; \sum_\tau \nabla_\theta p_\theta(\tau) \cdot R(\tau)
-\;=\; \sum_\tau p_\theta(\tau) \cdot \nabla_\theta \log p_\theta(\tau) \cdot R(\tau)
-\;=\; \mathbb{E}_\tau \!\left[\, \nabla_\theta \log p_\theta(\tau) \cdot R(\tau) \,\right]
+\nabla_\theta J = \sum_\tau \nabla_\theta p_\theta(\tau) \cdot R(\tau)
+ = \sum_\tau p_\theta(\tau) \cdot \nabla_\theta \log p_\theta(\tau) \cdot R(\tau)
+ = \mathbb{E}_\tau \left[ \nabla_\theta \log p_\theta(\tau) \cdot R(\tau) \right]
 $$
 
 **Step 5.** Take $\log$ of the factored $p_\theta(\tau)$ and then the gradient:
 
 $$
-\nabla_\theta \log p_\theta(\tau) \;=\; \sum_t \nabla_\theta \log \pi_\theta(a_t \mid s_t)
+\nabla_\theta \log p_\theta(\tau) = \sum_t \nabla_\theta \log \pi_\theta(a_t \mid s_t)
 $$
 
 The $P(s_0)$ and transition terms drop out because they don't depend on $\theta$.
@@ -155,7 +155,7 @@ Here's a nice fact. For any function $b(s_t)$ that depends only on the state (no
 on the action we took):
 
 $$
-\mathbb{E}_{a \sim \pi}\!\left[\, \nabla_\theta \log \pi(a \mid s_t) \cdot b(s_t) \,\right] \;=\; 0
+\mathbb{E}_{a \sim \pi}\left[ \nabla_\theta \log \pi(a \mid s_t) \cdot b(s_t) \right] = 0
 $$
 
 Why? Because $b(s_t)$ doesn't depend on $a$, it pulls out of the expectation over
@@ -164,17 +164,17 @@ Here's the one-line proof of that inner identity:
 
 $$
 \mathbb{E}_a \bigl[\nabla \log \pi(a \mid s)\bigr]
-\;=\; \sum_a \pi(a \mid s) \cdot \frac{\nabla \pi(a \mid s)}{\pi(a \mid s)}
-\;=\; \sum_a \nabla \pi(a \mid s)
-\;=\; \nabla \sum_a \pi(a \mid s)
-\;=\; \nabla 1 \;=\; 0
+ = \sum_a \pi(a \mid s) \cdot \frac{\nabla \pi(a \mid s)}{\pi(a \mid s)}
+ = \sum_a \nabla \pi(a \mid s)
+ = \nabla \sum_a \pi(a \mid s)
+ =  \nabla 1  =  0
 $$
 
 So we can **subtract** any state-dependent $b(s_t)$ from our return estimate
 without changing the expected gradient:
 
 $$
-\nabla_\theta J \;=\; \mathbb{E}\!\left[\, \sum_t \nabla_\theta \log \pi(a_t \mid s_t) \cdot \bigl(\hat G_t - b(s_t)\bigr) \,\right]
+\nabla_\theta J = \mathbb{E}\left[ \sum_t \nabla_\theta \log \pi(a_t \mid s_t) \cdot \bigl(\hat G_t - b(s_t)\bigr) \right]
 $$
 
 Or in code-style:
@@ -191,7 +191,7 @@ $V(s_t)$. The difference between the observed return and the expected return is
 called the **advantage**:
 
 $$
-A_t \;=\; \hat G_t \,-\, V(s_t)
+A_t  =  \hat G_t  -  V(s_t)
 $$
 
 Read "advantage" literally: how much better (or worse) did this action turn out than
@@ -202,7 +202,7 @@ round — it tells you whether you played above or below expectation.
 The variance-reduced policy gradient:
 
 $$
-\nabla_\theta J \;=\; \mathbb{E}\!\left[\, \sum_t \nabla_\theta \log \pi(a_t \mid s_t) \cdot A_t \,\right]
+\nabla_\theta J = \mathbb{E}\left[ \sum_t \nabla_\theta \log \pi(a_t \mid s_t) \cdot A_t \right]
 $$
 
 Or in code-style:
@@ -219,7 +219,7 @@ gradient algorithm uses.
 Before we define GAE, one more building block: the **one-step TD error**.
 
 $$
-\delta_t \;=\; r_t \,+\, \gamma \, V(s_{t+1}) \,-\, V(s_t)
+\delta_t = r_t + \gamma V(s_{t+1}) - V(s_t)
 $$
 
 Or in code-style:
@@ -239,7 +239,7 @@ them to use:
 Use one TD error:
 
 $$
-A_t^{(1)} \;=\; \delta_t
+A_t^{(1)} = \delta_t
 $$
 
 Or in code-style:
@@ -255,7 +255,7 @@ Or in code-style:
 Sum rewards all the way to the episode end:
 
 $$
-A_t^{(\infty)} \;=\; \sum_{k=t}^{T-1} \gamma^{k-t} \, r_k \;-\; V(s_t)
+A_t^{(\infty)} = \sum_{k=t}^{T-1} \gamma^{k-t} r_k - V(s_t)
 $$
 
 Or in code-style:
@@ -271,13 +271,13 @@ You can also use $n$ real rewards and then bootstrap with $V$:
 
 $$
 A_t^{(n)}
-\;=\; r_t + \gamma\, r_{t+1} + \cdots + \gamma^{n-1}\, r_{t+n-1} + \gamma^n V(s_{t+n}) \,-\, V(s_t)
+ = r_t + \gamma r_{t+1} + \cdots + \gamma^{n-1} r_{t+n-1} + \gamma^n V(s_{t+n}) - V(s_t)
 $$
 
 An equivalent form in terms of TD errors:
 
 $$
-A_t^{(n)} \;=\; \sum_{k=0}^{n-1} \gamma^k \, \delta_{t+k}
+A_t^{(n)} = \sum_{k=0}^{n-1} \gamma^k \delta_{t+k}
 $$
 
 Or in code-style:
@@ -302,7 +302,7 @@ GAE is an exponentially weighted average of the n-step advantages for all $n \ge
 In terms of TD errors:
 
 $$
-A_t^{\mathrm{GAE}} \;=\; \sum_{k=0}^{\infty} (\gamma \lambda)^k \, \delta_{t+k}
+A_t^{\mathrm{GAE}} = \sum_{k=0}^{\infty} (\gamma \lambda)^k \delta_{t+k}
 $$
 
 Or in code-style:
@@ -324,9 +324,9 @@ $(\gamma \lambda)$ from the rest:
 
 $$
 A_t^{\mathrm{GAE}}
-\;=\; \delta_t \,+\, \sum_{k=1}^{\infty} (\gamma\lambda)^k \, \delta_{t+k}
-\;=\; \delta_t \,+\, (\gamma\lambda) \sum_{k=0}^{\infty} (\gamma\lambda)^k \, \delta_{t+1+k}
-\;=\; \delta_t \,+\, (\gamma\lambda) \, A_{t+1}^{\mathrm{GAE}}
+ = \delta_t + \sum_{k=1}^{\infty} (\gamma\lambda)^k \delta_{t+k}
+ = \delta_t + (\gamma\lambda) \sum_{k=0}^{\infty} (\gamma\lambda)^k \delta_{t+1+k}
+ = \delta_t + (\gamma\lambda) A_{t+1}^{\mathrm{GAE}}
 $$
 
 Or in code-style:
@@ -338,7 +338,7 @@ Or in code-style:
 So the GAE advantage satisfies the one-line recursion:
 
 $$
-A_t \;=\; \delta_t \,+\, \gamma\lambda \, A_{t+1}
+A_t = \delta_t + \gamma\lambda A_{t+1}
 $$
 
 Boundary condition: at the terminal time $T$, the episode is over, so $V(s_T) = 0$
@@ -367,7 +367,7 @@ zeroed out.
 After computing advantages, the value head needs a regression target. We use:
 
 $$
-R_t \;=\; A_t \,+\, V_t
+R_t  =  A_t  +  V_t
 $$
 
 Or in code-style:
@@ -412,7 +412,7 @@ In classical RL, the environment hands you a reward at every step. For text we
 have to *construct* the per-token reward ourselves:
 
 $$
-r_t \;=\; -\beta \cdot \mathrm{KL}_t(\pi_\theta \,\|\, \pi_{\mathrm{ref}}) \;+\; r_{\mathrm{RM}}(y) \cdot \mathbf{1}[\,t = T_{\mathrm{last}}\,]
+r_t = -\beta \cdot \mathrm{KL}_t(\pi_\theta \| \pi_{\mathrm{ref}}) + r_{\mathrm{RM}}(y) \cdot \mathbf{1}[ t = T_{\mathrm{last}} ]
 $$
 
 Or in code-style:
@@ -449,11 +449,11 @@ Before feeding advantages into the PPO policy loss, normalize them across valid
 tokens so they have mean 0 and std 1:
 
 $$
-\mu \;=\; \frac{\sum_{b,t} m_{b,t}\, A_{b,t}}{\sum_{b,t} m_{b,t}},
+\mu = \frac{\sum_{b,t} m_{b,t} A_{b,t}}{\sum_{b,t} m_{b,t}},
 \qquad
-\sigma^2 \;=\; \frac{\sum_{b,t} m_{b,t}\, (A_{b,t} - \mu)^2}{\sum_{b,t} m_{b,t}},
+\sigma^2 = \frac{\sum_{b,t} m_{b,t} (A_{b,t} - \mu)^2}{\sum_{b,t} m_{b,t}},
 \qquad
-\tilde A \;=\; \frac{A - \mu}{\sqrt{\sigma^2} + \varepsilon}
+\tilde A = \frac{A - \mu}{\sqrt{\sigma^2} + \varepsilon}
 $$
 
 Or in code-style:

--- a/notes/04-ppo-kl.md
+++ b/notes/04-ppo-kl.md
@@ -16,6 +16,64 @@ By the end you should be able to:
 
 ---
 
+## 0. A five-minute KL divergence primer
+
+Before we use KL divergence, we should know what it is. If you already do, skim
+this and keep going.
+
+KL divergence is a number that measures **how different two probability
+distributions are**, from the point of view of one of them. For two distributions
+$P$ and $Q$ over the same set of outcomes, the KL divergence from $P$ to $Q$ is:
+
+$$
+\mathrm{KL}(P \| Q) = \sum_x P(x) \cdot \log \frac{P(x)}{Q(x)}
+$$
+
+Or in code-style:
+
+    KL(P || Q) = sum over x of P(x) * log( P(x) / Q(x) )
+
+Five facts to internalize:
+
+1. **It is always non-negative.** $\mathrm{KL}(P \| Q) \ge 0$, with equality iff
+   $P = Q$ everywhere. (This follows from Jensen's inequality applied to the
+   concave function $\log$.)
+2. **It is not symmetric.** $\mathrm{KL}(P \| Q) \ne \mathrm{KL}(Q \| P)$ in
+   general. Despite the name "divergence", it is not a proper distance.
+3. **Units are nats**, because we used natural log. Multiply by
+   $1/\ln 2 \approx 1.44$ to convert to bits.
+4. **It's an expectation under $P$.** $\sum_x P(x) \log(P(x)/Q(x))$ can be read
+   as $\mathbb{E}_{x \sim P}[\log(P(x)/Q(x))]$ — the average log-ratio, averaged
+   over samples drawn from $P$. This is important because PPO only has samples
+   from one distribution.
+5. **It equals zero iff the two distributions agree everywhere.** The smallest
+   disagreement gives a strictly positive number.
+
+A tiny worked example. Say the vocabulary has three outcomes. Policy $\pi$ thinks
+the probabilities are $(0.5,\, 0.3,\, 0.2)$. Reference $\pi_{\mathrm{ref}}$ thinks
+$(0.4,\, 0.4,\, 0.2)$. Plug in:
+
+$$
+\mathrm{KL}(\pi \| \pi_{\mathrm{ref}})
+= 0.5 \log\tfrac{0.5}{0.4} + 0.3 \log\tfrac{0.3}{0.4} + 0.2 \log\tfrac{0.2}{0.2}
+\approx 0.5(0.223) + 0.3(-0.288) + 0.2(0)
+\approx 0.025 \text{ nats}
+$$
+
+Very small. The two distributions are nearly identical. KL grows fast as
+distributions pull apart: if $\pi_{\mathrm{ref}}$ put zero probability on some
+outcome that $\pi$ puts positive probability on, the log-ratio would blow up and
+KL would be infinite. That's why we can't start PPO from random weights; the
+KL penalty would be meaningless.
+
+Intuition for why KL shows up in RLHF: the SFT policy $\pi_{\mathrm{ref}}$ is our
+"sane, coherent English" distribution. Any movement of $\pi_\theta$ away from it
+is reported as a KL number, and we can put a price on that movement. The
+optimization then decides, at every token, whether chasing extra reward is worth
+the KL cost.
+
+---
+
 ## 1. Why a KL penalty?
 
 The reward model is an imperfect proxy for human judgment. If we optimize it

--- a/notes/04-ppo-kl.md
+++ b/notes/04-ppo-kl.md
@@ -29,7 +29,7 @@ model), measured in KL divergence. The RL objective becomes:
 
 $$
 J_{\mathrm{RLHF}}(\theta)
-\;=\; \mathbb{E}\!\left[\, r_{\mathrm{RM}}(\tau) \;-\; \beta \sum_t \mathrm{KL}\bigl(\pi_\theta(\cdot \mid s_t) \,\|\, \pi_{\mathrm{ref}}(\cdot \mid s_t)\bigr) \,\right]
+ = \mathbb{E}\left[ r_{\mathrm{RM}}(\tau) - \beta \sum_t \mathrm{KL}\bigl(\pi_\theta(\cdot \mid s_t) \| \pi_{\mathrm{ref}}(\cdot \mid s_t)\bigr) \right]
 $$
 
 Or in code-style:
@@ -62,7 +62,7 @@ Option B: distribute the KL penalty across tokens, one per step.
 InstructGPT picks option B. The per-token reward becomes:
 
 $$
-r_t \;=\; -\beta \cdot \mathrm{KL}_t \;+\; r_{\mathrm{RM}} \cdot \mathbf{1}[\,t = T_{\mathrm{last}}\,]
+r_t = -\beta \cdot \mathrm{KL}_t + r_{\mathrm{RM}} \cdot \mathbf{1}[ t = T_{\mathrm{last}} ]
 $$
 
 Or in code-style:
@@ -92,8 +92,8 @@ We want to estimate the KL divergence between the two policies *at that state*,
 defined as:
 
 $$
-\mathrm{KL}\bigl(\pi_\theta(\cdot \mid s_t) \,\|\, \pi_{\mathrm{ref}}(\cdot \mid s_t)\bigr)
-\;=\; \mathbb{E}_{a \sim \pi_\theta}\!\left[\, \log \pi_\theta(a \mid s_t) \,-\, \log \pi_{\mathrm{ref}}(a \mid s_t) \,\right]
+\mathrm{KL}\bigl(\pi_\theta(\cdot \mid s_t) \| \pi_{\mathrm{ref}}(\cdot \mid s_t)\bigr)
+ = \mathbb{E}_{a \sim \pi_\theta}\left[ \log \pi_\theta(a \mid s_t) - \log \pi_{\mathrm{ref}}(a \mid s_t) \right]
 $$
 
 Or in code-style:
@@ -107,9 +107,9 @@ one sample $a_t$ drawn from $\pi_\theta$. What's our best single-sample estimate
 Define the log-ratio for the token we drew:
 
 $$
-L_t \;=\; \log \pi_\theta(a_t \mid s_t) \,-\, \log \pi_{\mathrm{ref}}(a_t \mid s_t),
+L_t = \log \pi_\theta(a_t \mid s_t) - \log \pi_{\mathrm{ref}}(a_t \mid s_t),
 \qquad
-\rho_t \;=\; e^{L_t}
+\rho_t = e^{L_t}
 $$
 
 Or in code-style:
@@ -122,7 +122,7 @@ Three standard estimators, $k_1$, $k_2$, $k_3$:
 ### 3.1 $k_1$: the naive log-ratio
 
 $$
-k_1 \;=\; L_t
+k_1  =  L_t
 $$
 
 Or in code-style:
@@ -141,7 +141,7 @@ exactly what we use in `shape_reward`.
 ### 3.2 $k_2$: half-squared log-ratio
 
 $$
-k_2 \;=\; \tfrac{1}{2} L_t^2
+k_2  =  \tfrac{1}{2} L_t^2
 $$
 
 Or in code-style:
@@ -157,7 +157,7 @@ Or in code-style:
 ### 3.3 $k_3$: Schulman's unbiased-and-nonnegative
 
 $$
-k_3 \;=\; (\rho_t - 1) \,-\, L_t \;=\; e^{L_t} - 1 - L_t
+k_3 = (\rho_t - 1) - L_t = e^{L_t} - 1 - L_t
 $$
 
 Or in code-style:
@@ -170,7 +170,7 @@ Or in code-style:
   convexity of $e^x$). Equality only when $x = 0$.
 - **Unbiased** (with a caveat).
 - **Lower variance than $k_1$** in practice: when $k_1$ has a big-magnitude
-  negative sample, $k_3$ pulls it back up via the $\rho - 1$ term, and vice versa.
+ negative sample, $k_3$ pulls it back up via the $\rho - 1$ term, and vice versa.
 
 A quick geometric picture: `k_1` is just the raw log-ratio of whatever token you
 happened to draw. `k_3` adds a symmetric correction penalizing any deviation of
@@ -208,7 +208,7 @@ Putting it all together. After a rollout we have:
 Compute the per-token KL:
 
 $$
-\mathrm{KL}_{k1}[b, t] \;=\; \log \pi_\theta^{\text{old}}(a_t \mid s_t) \,-\, \log \pi_{\mathrm{ref}}(a_t \mid s_t)
+\mathrm{KL}_{k1}[b, t] = \log \pi_\theta^{\text{old}}(a_t \mid s_t) - \log \pi_{\mathrm{ref}}(a_t \mid s_t)
 $$
 
 Or in code-style:
@@ -218,7 +218,7 @@ Or in code-style:
 And the per-token reward:
 
 $$
-r[b, t] \;=\; -\beta \cdot \mathrm{KL}_{k1}[b, t] \cdot m[b, t] \;+\; r_{\mathrm{RM}}[b] \cdot \mathbf{1}[\,t = T_{\mathrm{last}}(b)\,]
+r[b, t] = -\beta \cdot \mathrm{KL}_{k1}[b, t] \cdot m[b, t] + r_{\mathrm{RM}}[b] \cdot \mathbf{1}[ t = T_{\mathrm{last}}(b) ]
 $$
 
 Or in code-style:

--- a/notes/04-ppo-policy.md
+++ b/notes/04-ppo-policy.md
@@ -6,7 +6,7 @@ Theory packet for Problems 4.5, 4.6, and 4.7. Derive and reason about the three
 terms that make up the PPO loss:
 
 $$
-L_{\mathrm{PPO}} \;=\; L_{\mathrm{policy}} \,+\, c_v \cdot L_{\mathrm{value}} \,-\, c_{\mathrm{ent}} \cdot H
+L_{\mathrm{PPO}} = L_{\mathrm{policy}} + c_v \cdot L_{\mathrm{value}} - c_{\mathrm{ent}} \cdot H
 $$
 
 Or in code-style:
@@ -28,7 +28,7 @@ By the end you should be able to:
 Recall from `04-ppo-gae.md` that the policy gradient with advantage baseline is:
 
 $$
-\nabla_\theta J \;=\; \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\, \sum_t \nabla_\theta \log \pi_\theta(a_t \mid s_t) \cdot A_t \,\right]
+\nabla_\theta J = \mathbb{E}_{\tau \sim \pi_\theta}\left[ \sum_t \nabla_\theta \log \pi_\theta(a_t \mid s_t) \cdot A_t \right]
 $$
 
 Or in code-style:
@@ -47,15 +47,15 @@ $\pi_{\mathrm{old}}$, frozen at the start of the current outer iteration. We rew
 the objective as an expectation under $\pi_{\mathrm{old}}$ with an importance weight:
 
 $$
-J(\theta) \;=\; \mathbb{E}_{\tau \sim \pi_{\mathrm{old}}}\!\left[\, \sum_t \rho_t(\theta) \cdot A_t \,\right]
+J(\theta) = \mathbb{E}_{\tau \sim \pi_{\mathrm{old}}}\left[ \sum_t \rho_t(\theta) \cdot A_t \right]
 $$
 
 where the **importance ratio** is:
 
 $$
 \rho_t(\theta)
-\;=\; \frac{\pi_\theta(a_t \mid s_t)}{\pi_{\mathrm{old}}(a_t \mid s_t)}
-\;=\; \exp\!\bigl(\log \pi_\theta(a_t \mid s_t) \,-\, \log \pi_{\mathrm{old}}(a_t \mid s_t)\bigr)
+ = \frac{\pi_\theta(a_t \mid s_t)}{\pi_{\mathrm{old}}(a_t \mid s_t)}
+ = \exp\bigl(\log \pi_\theta(a_t \mid s_t) - \log \pi_{\mathrm{old}}(a_t \mid s_t)\bigr)
 $$
 
 Or in code-style:
@@ -81,9 +81,9 @@ the batch while preventing the policy from moving too far per update.
 For each token, define two candidate surrogates:
 
 $$
-\mathrm{surr}_1 \;=\; \rho \cdot A,
+\mathrm{surr}_1 = \rho \cdot A,
 \qquad
-\mathrm{surr}_2 \;=\; \mathrm{clip}(\rho,\, 1 - \varepsilon,\, 1 + \varepsilon) \cdot A
+\mathrm{surr}_2 = \mathrm{clip}(\rho, 1 - \varepsilon, 1 + \varepsilon) \cdot A
 $$
 
 where $\mathrm{clip}(x, \text{lo}, \text{hi})$ pins $x$ to the range
@@ -97,13 +97,13 @@ Or in code-style:
 The PPO per-token loss is:
 
 $$
-L_{\mathrm{clip},t} \;=\; -\min(\mathrm{surr}_1,\, \mathrm{surr}_2)
+L_{\mathrm{clip},t} = -\min(\mathrm{surr}_1, \mathrm{surr}_2)
 $$
 
 And the total policy loss, normalized by the number of valid tokens:
 
 $$
-L_{\mathrm{policy}} \;=\; \frac{1}{N} \sum_{b,t} m_{b,t} \cdot L_{\mathrm{clip},t}
+L_{\mathrm{policy}} = \frac{1}{N} \sum_{b,t} m_{b,t} \cdot L_{\mathrm{clip},t}
 $$
 
 Or in code-style:
@@ -147,13 +147,13 @@ For the unclipped case, the per-token loss is $L = -\rho A$. Using
 $\rho = \exp(\log \pi_\theta - \log \pi_{\mathrm{old}})$:
 
 $$
-\frac{\partial \rho}{\partial \log \pi_\theta} \;=\; \rho
+\frac{\partial \rho}{\partial \log \pi_\theta} = \rho
 $$
 
 So by the chain rule:
 
 $$
-\frac{\partial L}{\partial \log \pi_\theta} \;=\; -A \cdot \rho
+\frac{\partial L}{\partial \log \pi_\theta} = -A \cdot \rho
 $$
 
 Or in code-style:
@@ -169,7 +169,7 @@ The clip saturates, so changing $\log \pi_\theta$ doesn't change $\mathrm{surr}_
 Therefore:
 
 $$
-\frac{\partial L}{\partial \log \pi_\theta} \;=\; 0
+\frac{\partial L}{\partial \log \pi_\theta} = 0
 $$
 
 Or in code-style:
@@ -207,7 +207,7 @@ why everyone uses PPO.
 The value head's job is to regress toward the GAE return:
 
 $$
-R_t \;=\; A_t \,+\, V_{\mathrm{old}}(s_t)
+R_t = A_t + V_{\mathrm{old}}(s_t)
 $$
 
 which is computed at rollout time and treated as a constant during optimization
@@ -218,7 +218,7 @@ which is computed at rollout time and treated as a constant during optimization
 The simplest value loss is plain MSE:
 
 $$
-L_{V,\mathrm{unclipped}} \;=\; \frac{1}{2N} \sum_{b,t} m_{b,t} \cdot \bigl(V_\theta(s_t) - R_t\bigr)^2
+L_{V,\mathrm{unclipped}} = \frac{1}{2N} \sum_{b,t} m_{b,t} \cdot \bigl(V_\theta(s_t) - R_t\bigr)^2
 $$
 
 Or in code-style:
@@ -232,17 +232,17 @@ Gradient is `mask * (V_theta - R) * dV_theta/dtheta` — standard MSE.
 The clipped value loss mirrors the policy clip. Define:
 
 $$
-V_{\mathrm{clipped}}(s_t) \;=\; V_{\mathrm{old}}(s_t) \,+\, \mathrm{clip}\bigl(V_\theta(s_t) - V_{\mathrm{old}}(s_t),\; -\varepsilon_v,\; +\varepsilon_v\bigr)
+V_{\mathrm{clipped}}(s_t) = V_{\mathrm{old}}(s_t) + \mathrm{clip}\bigl(V_\theta(s_t) - V_{\mathrm{old}}(s_t), -\varepsilon_v, +\varepsilon_v\bigr)
 $$
 
 Then:
 
 $$
-\mathrm{per\text{-}tok\, loss} \;=\; \tfrac{1}{2} \, \max\!\left((V_\theta - R)^2,\; (V_{\mathrm{clipped}} - R)^2\right)
+\mathrm{per\text{-}tok loss} = \tfrac{1}{2} \max\left((V_\theta - R)^2, (V_{\mathrm{clipped}} - R)^2\right)
 $$
 
 $$
-L_V \;=\; \frac{1}{N} \sum_{b,t} m_{b,t} \cdot \mathrm{per\text{-}tok\, loss}_{b,t}
+L_V = \frac{1}{N} \sum_{b,t} m_{b,t} \cdot \mathrm{per\text{-}tok loss}_{b,t}
 $$
 
 Or in code-style:
@@ -299,7 +299,7 @@ you'd compute by hand for the selected branch.
 Add the negated entropy of the policy to the loss:
 
 $$
-L_{\mathrm{total}} \;=\; L_{\mathrm{policy}} \,+\, c_v \cdot L_{\mathrm{value}} \,-\, c_{\mathrm{ent}} \cdot H(\pi_\theta)
+L_{\mathrm{total}} = L_{\mathrm{policy}} + c_v \cdot L_{\mathrm{value}} - c_{\mathrm{ent}} \cdot H(\pi_\theta)
 $$
 
 Or in code-style:
@@ -320,13 +320,13 @@ near zero, generations getting repetitive), bump it to `0.01`.
 For one position, the entropy of the per-token distribution $p$ over the vocab is:
 
 $$
-H(p) \;=\; -\sum_v p_v \, \log p_v
+H(p) = -\sum_v p_v \log p_v
 $$
 
 For a batch of positions:
 
 $$
-H_{\mathrm{batch}} \;=\; \frac{1}{N} \sum_{b,t} m_{b,t} \cdot H(p_{b,t})
+H_{\mathrm{batch}} = \frac{1}{N} \sum_{b,t} m_{b,t} \cdot H(p_{b,t})
 $$
 
 Or in code-style:
@@ -339,7 +339,7 @@ Or in code-style:
 Let $z$ be the logits and $p = \mathrm{softmax}(z)$. Start from the definition:
 
 $$
-H \;=\; -\sum_v p_v \, \log p_v
+H = -\sum_v p_v \log p_v
 $$
 
 Differentiating $p_v \log p_v$ with respect to $z_u$ gives
@@ -348,7 +348,7 @@ $\partial \log p_v / \partial p_v = 1/p_v$). So:
 
 $$
 \frac{\partial H}{\partial z_u}
-\;=\; -\sum_v \frac{\partial p_v}{\partial z_u} \cdot \bigl(\log p_v + 1\bigr)
+ = -\sum_v \frac{\partial p_v}{\partial z_u} \cdot \bigl(\log p_v + 1\bigr)
 $$
 
 Now plug in the softmax derivative
@@ -356,7 +356,7 @@ $\partial p_v / \partial z_u = p_v(\delta_{v,u} - p_u)$ from `02-sft.md`:
 
 $$
 \frac{\partial H}{\partial z_u}
-\;=\; -\sum_v p_v (\delta_{v,u} - p_u) \cdot (\log p_v + 1)
+ = -\sum_v p_v (\delta_{v,u} - p_u) \cdot (\log p_v + 1)
 $$
 
 Split the $(\delta_{v,u} - p_u)$ into the two pieces. The $\delta_{v,u}$ piece picks
@@ -364,7 +364,7 @@ out only the $v = u$ term. The $-p_u$ piece factors out of the sum:
 
 $$
 \frac{\partial H}{\partial z_u}
-\;=\; -\,p_u (\log p_u + 1) \;+\; p_u \sum_v p_v (\log p_v + 1)
+ = - p_u (\log p_u + 1) + p_u \sum_v p_v (\log p_v + 1)
 $$
 
 The sum on the right equals $-H + 1$ (since $\sum_v p_v \log p_v = -H$ and
@@ -372,14 +372,14 @@ $\sum_v p_v = 1$). Substitute:
 
 $$
 \frac{\partial H}{\partial z_u}
-\;=\; -p_u (\log p_u + 1) \,+\, p_u \cdot (-H + 1)
-\;=\; -p_u \,(\log p_u + H)
+ = -p_u (\log p_u + 1) + p_u \cdot (-H + 1)
+ = -p_u (\log p_u + H)
 $$
 
 In vector form:
 
 $$
-\nabla_z H \;=\; -p \,\odot\, (\log p + H)
+\nabla_z H = -p \odot (\log p + H)
 $$
 
 (elementwise product). Or in code-style:

--- a/notes/04-ppo-policy.md
+++ b/notes/04-ppo-policy.md
@@ -25,6 +25,22 @@ By the end you should be able to:
 
 ## 1. Setup: importance-sampled policy gradient
 
+Before the equations, a plain-English sketch of PPO's one idea. Vanilla policy
+gradient says: sample a trajectory from the current policy, and nudge the
+parameters so the good actions become more likely. Two problems:
+
+1. Sampling trajectories is expensive — each one requires a full autoregressive
+   generation of up to 256 tokens. We'd rather reuse each batch of samples for
+   several gradient steps.
+2. Once we've taken a step, the old samples aren't drawn from the new policy
+   anymore, so the naive gradient is biased.
+
+PPO fixes both with a two-step trick: (a) use importance sampling to reuse the
+batch for multiple gradient updates, and (b) *clip* the importance ratio so that
+after a few updates the policy can't wander far enough from the rollout policy
+to make the estimator blow up. The rest of this note is just making that trick
+precise.
+
 Recall from `04-ppo-gae.md` that the policy gradient with advantage baseline is:
 
 $$
@@ -119,6 +135,27 @@ objective (before the negation), we take the *minimum* of `surr1` and `surr2`,
 i.e. the less favorable one. This is the key idea — the surrogate is set up so
 that the policy cannot be rewarded for running the ratio far outside
 `[1 - eps, 1 + eps]` in the direction of increasing the objective.
+
+A quick sanity check with numbers. Set $\varepsilon = 0.2$ so the clip range is
+$[0.8,\, 1.2]$. Pick two tokens:
+
+- **Token A (good action).** Advantage $A = +1$ (this action turned out better
+  than expected). Current ratio $\rho = 1.5$ — the policy has moved so that this
+  token is 1.5x more likely than it was at rollout. Compute:
+  $\mathrm{surr}_1 = 1.5$, $\mathrm{surr}_2 = 1.2$. $\min = 1.2$. Loss
+  $= -1.2$. The gradient is **zero** because the flat clipped branch won the
+  $\min$ — no further pushing this token upward; it's already moved too far.
+- **Token B (bad action).** Advantage $A = -1$. Ratio $\rho = 1.5$. Compute:
+  $\mathrm{surr}_1 = -1.5$, $\mathrm{surr}_2 = -1.2$. $\min = -1.5$. Loss
+  $= +1.5$. The gradient is **non-zero** and it pushes $\rho$ down — which is
+  what we want, because this action turned out badly and we want to make it
+  less likely. The clip does NOT fire here, because firing it would soften our
+  response to a bad action we want to suppress.
+
+That asymmetry is the whole point: we are only "pessimistic" (clip to avoid big
+moves) when the policy would otherwise enjoy a reward for a move that has already
+gotten extreme. If the move is extreme in a *costly* direction, we let the
+gradient keep flowing.
 
 ### 2.2 What "pessimistic" means, case by case
 


### PR DESCRIPTION
## Summary
This PR standardizes LaTeX equation formatting across all theory notes and adds substantial pedagogical content to improve clarity for readers new to the concepts.

## Key Changes

**LaTeX Formatting Standardization:**
- Replaced inconsistent spacing around `=` signs in equations (e.g., `\;=\;` → `=`)
- Standardized spacing in expectation operators (e.g., `\mathbb{E}_{\tau \sim \pi_\theta}\!\left[\, ... \,\right]` → `\mathbb{E}_{\tau \sim \pi_\theta}\left[ ... \right]`)
- Removed excessive `\!` negative spacing operators for cleaner, more consistent rendering
- Applied consistent spacing around operators like `\|`, `+`, `-`, `\cdot` throughout

**New Pedagogical Content:**

1. **04-ppo-gae.md:**
   - Added Section 1.1 "A concrete rollout" with a detailed table showing a concrete example of state-action-reward tuples during text generation
   - Expanded explanation of the log-derivative trick in Step 3 with intuition about why it's used
   - Clarified that the log-derivative trick converts "gradient of a probability" into "probability times gradient of log-probability"

2. **04-ppo-policy.md:**
   - Added plain-English sketch of PPO's core idea before equations, explaining the two main problems (sampling cost and distribution shift) and how PPO solves them
   - Added detailed numerical sanity check (Section 2.1) with concrete examples of Token A (good action) and Token B (bad action) showing how clipping works in practice
   - Explained the asymmetry in clipping behavior and why it's desirable

3. **04-ppo-kl.md:**
   - Added comprehensive Section 0 "A five-minute KL divergence primer" covering:
     - Definition and intuition for KL divergence
     - Five key facts (non-negativity, asymmetry, units, expectation form, zero iff equal)
     - Worked numerical example with three-token vocabulary
     - Intuition for why KL appears in RLHF

4. **02-sft.md:**
   - Added Section 4.4 "A worked example with numbers" showing softmax, loss, and gradient computation with concrete values
   - Demonstrates how gradient descent updates logits and improves model confidence
   - Added Section 4.5 label clarification for the mask section

5. **03-rm.md:**
   - Added Section 4.5 "A worked example with numbers" showing Bradley-Terry loss computation with concrete values
   - Demonstrates both confident-correct and confidently-wrong cases
   - Illustrates the self-regulating nature of logistic regression loss

6. **01-gpt2.md:**
   - Applied consistent LaTeX formatting throughout (no new content)

## Implementation Details
- All equation formatting changes maintain mathematical correctness while improving readability
- New examples use realistic numbers and step-by-step calculations to build intuition
- Pedagogical additions are positioned before or after relevant theory sections to provide context
- All changes are backward compatible with existing content

https://claude.ai/code/session_01FzV9R99yDbnYDuarjxGGk3