### PR TITLE
Scrub AI-writing tics and add worked examples across notes

### DIFF
--- a/notes/00-data.md
+++ b/notes/00-data.md
@@ -47,9 +47,9 @@ Here is what a raw row looks like:
 ```
 
 Both strings are the full dialogue, including all earlier turns. Usually only the final
-assistant turn differs between chosen and rejected, but not always — in principle the
-conversations could diverge earlier. Treat them as two full trajectories, not as
-"one prompt with two possible endings".
+assistant turn differs between chosen and rejected, but in principle the conversations
+could diverge earlier. The safe mental model is two full trajectories that happen to share
+a prefix.
 
 For the teaching implementation, we still usually *extract* a shared prompt and two candidate
 responses. But while doing that extraction, keep the raw fact in mind: the dataset does not
@@ -123,6 +123,92 @@ main line. Literal tags are verbose but transparent.
 We write the roles as `user` and `assistant`. The raw HH data uses `Human:` and
 `Assistant:` instead, so part of your formatter's job is to translate `Human:` → `user`
 and `Assistant:` → `assistant` while wrapping everything in the ChatML tags.
+
+### Worked example: raw HH row to chat-formatted string
+
+Pretend the raw HH row is short:
+
+```json
+{
+  "chosen":   "\n\nHuman: What is 2+2?\n\nAssistant: 4.",
+  "rejected": "\n\nHuman: What is 2+2?\n\nAssistant: I'm not sure."
+}
+```
+
+After your formatter applies the ChatML template, the `chosen` side becomes:
+
+```
+<|im_start|>user
+What is 2+2?<|im_end|>
+<|im_start|>assistant
+4.<|im_end|>
+```
+
+The `rejected` side becomes:
+
+```
+<|im_start|>user
+What is 2+2?<|im_end|>
+<|im_start|>assistant
+I'm not sure.<|im_end|>
+```
+
+Both share the prompt prefix up through the second `<|im_start|>assistant\n`. From this
+point on, the SFT dataset will use the chosen string, the RM will use both, and the PPO
+prompt-only dataset will keep just the prefix.
+
+### Worked example: tokens and loss_mask alignment
+
+The full BPE expansion of the chat template is verbose (each `<|im_start|>` literal
+splits into about half a dozen subwords). To make the structure visible, this note uses
+a tiny printed vocab with one token per logical piece. The *real* code uses the actual
+GPT-2 BPE; the alignment rule is the same.
+
+```
+toy vocab:
+   0: <pad>
+  10: <|im_start|>user\n
+  11: What
+  12: is
+  13: 2+2
+  14: ?
+  15: <|im_end|>
+  16: <|im_start|>assistant\n
+  17: 4
+  18: .
+```
+
+The chat-formatted `chosen` string tokenizes to:
+
+```
+pos:        0   1   2   3   4   5   6   7   8
+input_id:  10  11  12  13  14  15  16  17  18  15
+                                                ^
+                                                pos 9: closing <|im_end|>
+```
+
+Now the SFT mask. The rule from §3.1 is "1 only on assistant content, including the
+trailing `<|im_end|>`." Apply it position-by-position:
+
+```
+pos:         0   1   2   3   4   5   6   7   8   9
+input_id:   10  11  12  13  14  15  16  17  18  15
+piece:       U   W   I   2   ?  /U   A   4   .  /A
+loss_mask:   0   0   0   0   0   0   0   1   1   1
+```
+
+Legend: `U` = user header, `W/I/2/?` = user content, `/U` = user closing `<|im_end|>`,
+`A` = assistant header, `4/.` = assistant content, `/A` = assistant closing `<|im_end|>`.
+
+Two things to verify when staring at this:
+
+- The assistant header at position 6 (`<|im_start|>assistant\n`) is `mask = 0`. Your
+  inference code emits that token; the model never has to predict it.
+- The assistant's closing `<|im_end|>` at position 9 is `mask = 1`. The model must
+  learn when to stop, which means it must learn to emit that closing token.
+
+Module 2 (`02-sft.md`) revisits the same example after the shift to the predict-next
+frame, where the mask attaches to the *target* token rather than the *input* token.
 
 ---
 

--- a/notes/01-gpt2.md
+++ b/notes/01-gpt2.md
@@ -4,8 +4,8 @@
 
 This is the theory packet for Module 1 (Problems 1.1 through 1.8). Read through the
 whole thing once before you start typing, then re-read the relevant section right
-before each problem. By the end of Module 1 you should be able to draw every arrow —
-forward and backward — of GPT-2 on a whiteboard without looking anything up.
+before each problem. By the end of Module 1 you should be able to draw every arrow,
+forward and backward, of GPT-2 on a whiteboard without looking anything up.
 
 In this repo, GPT-2 is a sequence of tensor operations with a few repeated patterns. Once you
 can track the residual stream shape through one block, you can track it through all blocks.
@@ -192,11 +192,48 @@ axis.
 - Using unbiased variance (dividing by `C - 1`). PyTorch's `F.layer_norm` uses biased.
 - Putting `eps` outside the square root instead of inside.
 
+### Worked example: LayerNorm on a 4-dim vector
+
+Take one token's hidden vector with `C = 4`:
+
+    x = [1.0, 3.0, -1.0, 1.0]
+
+Mean: `mu = (1 + 3 - 1 + 1) / 4 = 1.0`. Centered: `[0, 2, -2, 0]`. Squared
+deviations: `[0, 4, 4, 0]`. Variance: `sigma^2 = 8 / 4 = 2.0` (note: divide by
+`C`, not `C - 1`). With `eps = 1e-5`:
+
+    sqrt(sigma^2 + eps) ≈ 1.41421
+    x_hat ≈ [0, 1.41421, -1.41421, 0] / 1.41421 ... wait, recompute
+
+Actually `x_hat[i] = (x[i] - mu) / sqrt(sigma^2 + eps)`:
+
+    x_hat ≈ [0/1.41421, 2/1.41421, -2/1.41421, 0/1.41421]
+          ≈ [0.000, +1.4142, -1.4142, 0.000]
+
+Quick check: mean of `x_hat` is 0 (good); variance of `x_hat` is
+`(0 + 2 + 2 + 0) / 4 = 1` (good).
+
+Now apply learned affine parameters. Suppose `gamma = [1, 2, 1, 0.5]` and
+`beta = [0.0, 0.0, 0.5, -0.5]`:
+
+    y[i] = gamma[i] * x_hat[i] + beta[i]
+    y ≈ [0.0, +2.8284, -0.9142, -0.5]
+
+The two takeaways from this example:
+
+- The "zero-mean, unit-variance" property holds *before* the affine step. After
+  `gamma` and `beta`, neither holds in general — those parameters intentionally
+  let the network rescale and shift.
+- Every output `y[i]` depends on every input `x[j]` (through `mu` and `sigma^2`).
+  That coupling is why the LayerNorm backward pass is messier than per-element
+  ops; PyTorch handles it for you, but it explains why the gradient at one
+  channel involves a sum over all channels.
+
 ---
 
 ## 4. Causal self-attention (Problem 1.3)
 
-Attention is the core of the transformer. Read this until the moves feel mechanical.
+Attention is the core of the transformer.
 
 ### 4.1 Produce Q, K, V
 
@@ -286,10 +323,10 @@ Or in code-style:
 
 That's the attention output per head, shape `(T, d_h)`.
 
-This weighted sum is why attention can copy, summarize, or combine earlier information. If
-one attention weight is nearly 1, the head behaves like a pointer to one previous token. If
-the weights are spread out, the head computes a soft summary over many previous positions.
-Language models learn both behaviors.
+This weighted sum is what lets attention copy, summarize, or combine earlier information.
+A weight near 1 makes the head behave like a pointer to one previous token. Weights spread
+out across positions make the head compute a soft summary. Language models learn both
+behaviors.
 
 ### 4.6 Why divide by `sqrt(d_h)`?
 
@@ -325,6 +362,112 @@ Common bugs that gradient-check still catches (or you'd hope it did):
   exactly zero anymore (softmax over finite numbers can't produce exact zero).
 - Messing up the head reshape order: `(B, T, n_h, d_h)` vs `(B, n_h, T, d_h)`. The
   attention matmul needs the head axis to come before the time axis.
+
+### 4.9 Worked example: causal mask on a 4-token sequence
+
+Score matrix `S` is `(T, T) = (4, 4)`. Before softmax, we set every entry above
+the diagonal to `-inf`:
+
+```
+       key=0    key=1    key=2    key=3
+q=0  [   s00     -inf     -inf     -inf  ]
+q=1  [   s10     s11      -inf     -inf  ]
+q=2  [   s20     s21      s22      -inf  ]
+q=3  [   s30     s31      s32      s33   ]
+```
+
+Softmax along the key axis (each row is normalised independently). The `-inf`
+positions become exactly zero:
+
+```
+       key=0    key=1    key=2    key=3
+q=0  [  1.000    0.000    0.000    0.000  ]
+q=1  [  alpha10  alpha11  0.000    0.000  ]
+q=2  [  alpha20  alpha21  alpha22  0.000  ]
+q=3  [  alpha30  alpha31  alpha32  alpha33 ]
+```
+
+Each row sums to 1. Position 0 attends only to itself, position 1 attends to
+{0, 1}, and so on. The attention output at position `t` is then
+`sum over s of alpha[t, s] * V[s]`, which only mixes value vectors from
+positions `0..t`.
+
+If you forget to apply the mask before softmax and just zero out the upper
+triangle of `alpha` after softmax, the rows no longer sum to 1 and you have
+implicitly let future tokens contribute to the normalisation constant. Autograd
+still computes a gradient, but the model has been trained with a small future
+leak.
+
+### 4.10 Worked example: a tiny end-to-end forward pass
+
+Use `T = 4`, `n_embd = C = 4`, `n_head = 2` (so `d_h = 2`). Pretend the input
+hidden state at position `t` (after embeddings + positional + LayerNorm) is:
+
+```
+x[0] = [ 1.0,  0.0,  0.0,  0.0 ]
+x[1] = [ 0.0,  1.0,  0.0,  0.0 ]
+x[2] = [ 0.0,  0.0,  1.0,  0.0 ]
+x[3] = [ 1.0,  1.0,  0.0,  0.0 ]
+```
+
+Suppose `W_qkv` is a small weight matrix that, after the matmul `x @ W_qkv`,
+reshape, and split, hands us:
+
+```
+head 0 (positions 0..3 stacked):
+  Q[h0] = [[1, 0], [0, 1], [0, 0], [1, 1]]
+  K[h0] = [[1, 0], [0, 1], [0, 0], [1, 1]]
+  V[h0] = [[1, 0], [0, 1], [0, 0], [1, 1]]
+```
+
+(Identity-ish for clarity; real weights mix channels.) Compute attention for
+head 0 only.
+
+Step 1: scores `S[t, s] = (Q[t] . K[s]) / sqrt(d_h)`, with `sqrt(2) ≈ 1.414`:
+
+```
+       key=0  key=1  key=2  key=3
+q=0  [ 0.707  0.000  0.000  0.707 ]   # cosine-like raw products / sqrt(2)
+q=1  [ 0.000  0.707  0.000  0.707 ]
+q=2  [ 0.000  0.000  0.000  0.000 ]
+q=3  [ 0.707  0.707  0.000  1.414 ]
+```
+
+Step 2: causal mask. Set every entry above the diagonal to `-inf`:
+
+```
+q=0  [ 0.707  -inf   -inf   -inf  ]
+q=1  [ 0.000  0.707  -inf   -inf  ]
+q=2  [ 0.000  0.000  0.000  -inf  ]
+q=3  [ 0.707  0.707  0.000  1.414 ]
+```
+
+Step 3: row softmax. Position 0 has only itself, so its row is
+`[1.0, 0, 0, 0]`. Position 2 has three equal values:
+`alpha = [1/3, 1/3, 1/3, 0]`. Position 3 with values `[0.707, 0.707, 0, 1.414]`
+gives `alpha ≈ [0.218, 0.218, 0.108, 0.456]` (after `exp` and normalization).
+
+Step 4: weighted sum of value vectors. For position 3:
+
+    o[3] = 0.218 * V[0] + 0.218 * V[1] + 0.108 * V[2] + 0.456 * V[3]
+         = 0.218 * [1, 0]
+         + 0.218 * [0, 1]
+         + 0.108 * [0, 0]
+         + 0.456 * [1, 1]
+         = [0.674, 0.674]
+
+Step 5: head 1 runs in parallel with its own Q/K/V (same algebra). Concatenate
+the per-head outputs, project through `W_o`, and add to the residual stream.
+
+Two things to internalize from this example:
+
+- Every position's output is a convex combination (weights non-negative,
+  summing to 1) of value vectors from earlier positions only. The causal mask
+  enforces "earlier"; the softmax enforces "convex combination."
+- Position 3's output has copied roughly half its contribution from position 3
+  itself (the diagonal weight `0.456`), with the rest blended from positions
+  0 and 1. Heads usually look like this: a small set of relevant earlier
+  positions dominate, and the rest contribute very little.
 
 ---
 
@@ -519,6 +662,40 @@ and guess.
 
 Once it passes, log the name-map table into this notes file so future-you can find it
 fast.
+
+### 8.1 Worked example: a slice of the name-map table
+
+A representative chunk of what the table should look like for a single block
+(here block 7), written so the transpose hazard is documented in the same row:
+
+```
+HF name                                    -> our name                       transpose? shape (HF -> ours)
+transformer.wte.weight                     -> wte.weight                       no       (V, C)            -> (V, C)
+transformer.wpe.weight                     -> wpe.weight                       no       (T_max, C)        -> (T_max, C)
+transformer.h.7.ln_1.weight                -> blocks[7].ln_1.weight            no       (C,)              -> (C,)
+transformer.h.7.ln_1.bias                  -> blocks[7].ln_1.bias              no       (C,)              -> (C,)
+transformer.h.7.attn.c_attn.weight         -> blocks[7].attn.c_attn.weight     YES      (C, 3C)           -> (3C, C)
+transformer.h.7.attn.c_attn.bias           -> blocks[7].attn.c_attn.bias       no       (3C,)             -> (3C,)
+transformer.h.7.attn.c_proj.weight         -> blocks[7].attn.c_proj.weight     YES      (C, C)            -> (C, C)
+transformer.h.7.mlp.c_fc.weight            -> blocks[7].mlp.c_fc.weight        YES      (C, 4C)           -> (4C, C)
+transformer.h.7.mlp.c_proj.weight          -> blocks[7].mlp.c_proj.weight      YES      (4C, C)           -> (C, 4C)
+transformer.ln_f.weight                    -> ln_f.weight                      no       (C,)              -> (C,)
+```
+
+The four `YES` rows are the Conv1D-stored linear weights. For each of those,
+copy over with `our_param.data.copy_(hf_weight.T)`. The biases on those same
+modules are 1D, so they have no orientation and do not need transposing.
+
+Sanity checks before you trust the loader:
+
+- Print every HF key that did *not* find a destination, and every destination
+  parameter that received nothing. Both lists should be empty.
+- After loading, run the parity test on a fixed prompt and assert
+  `max_abs_diff < 1e-4` on the final logits. Any failure here is almost
+  always a missed `T` on one of the four Conv1D linears.
+- Spot-check `wte.weight is lm_head.weight` (the same Python object). If it
+  is two separate tensors, the weight tying is broken and the parameter count
+  will be too high by `V * C`.
 
 ---
 

--- a/notes/02-sft.md
+++ b/notes/02-sft.md
@@ -162,8 +162,8 @@ Two big reasons.
 At inference time, **we** write the user's message — the model never has to
 generate user text. If we train on user tokens, the model wastes capacity memorizing
 human prompt phrasings, and worse, sometimes starts hallucinating "Human: ..." turns
-into its own output. This is the classic SFT failure mode where the model keeps
-inventing the other side of the conversation. Masking out user tokens prevents it.
+into its own output. The model learns to keep producing the other side of the conversation
+instead of stopping after one turn. Masking out user tokens prevents it.
 
 This is especially important with chat templates. The model should learn that after the
 assistant header it emits assistant content. It should not learn to continue by creating a
@@ -383,6 +383,129 @@ Three things worth noticing:
   scalars.
 - This is the gradient that flows from the loss into the `lm_head` and then
   backpropagates through the rest of the transformer.
+
+### 4.6 Worked example: end-to-end masked CE on a chat template
+
+Pick up the toy vocab from `00-data.md` and walk one example all the way through.
+The original (unshifted) tokens for the chosen dialogue were:
+
+```
+pos:        0   1   2   3   4   5   6   7   8   9
+input_id:  10  11  12  13  14  15  16  17  18  15
+piece:      U   W   I   2   ?  /U   A   4   .  /A
+mask m:     0   0   0   0   0   0   0   1   1   1
+```
+
+Now shift to the predict-next frame:
+
+```
+shifted pos:  0   1   2   3   4   5   6   7   8
+input_id:    10  11  12  13  14  15  16  17  18      # x[:-1]
+labels:      11  12  13  14  15  16  17  18  15      # x[1:]
+loss_mask:    0   0   0   0   0   0   1   1   1      # m[1:]
+```
+
+Three loss-mask positions: 6 predicts `17` (the assistant content `4`), 7 predicts
+`18` (the assistant content `.`), 8 predicts `15` (the closing `<|im_end|>`).
+
+Imagine the model produces these logits at each position over a vocab of size 4
+restricted to the relevant ids `{15, 16, 17, 18}`:
+
+```
+shifted pos:  6           7           8
+              for `4`:     for `.`:    for `</A>`:
+target:      17          18          15
+logits[15]:  -1.0        -1.0         2.0
+logits[16]:   0.0         0.0         0.0
+logits[17]:   2.0         0.0        -1.0
+logits[18]:   0.0         2.0         0.0
+```
+
+Per-position softmax probabilities (rounding to 3 figures):
+
+```
+pos 6:  p[15]=0.034  p[16]=0.094  p[17]=0.690  p[18]=0.094
+pos 7:  p[15]=0.034  p[16]=0.094  p[17]=0.094  p[18]=0.690
+pos 8:  p[15]=0.690  p[16]=0.094  p[17]=0.034  p[18]=0.094
+```
+
+Per-position cross-entropy at the supervised positions:
+
+```
+ell[6] = -log(0.690) ≈ 0.371      # target 17
+ell[7] = -log(0.690) ≈ 0.371      # target 18
+ell[8] = -log(0.690) ≈ 0.371      # target 15
+```
+
+`N_resp = sum(loss_mask) = 3`, so:
+
+```
+L_SFT = (0 + 0 + 0 + 0 + 0 + 0 + 0.371 + 0.371 + 0.371) / 3 ≈ 0.371
+```
+
+The unsupervised positions (0..5) contribute zero to the numerator and zero to the
+denominator. Whatever the model thinks about how to predict user tokens does not
+affect this loss.
+
+### 4.7 Worked example: flipping a masked label
+
+Same setup. Change `labels[2]` from `13` (toy id for `2+2`) to some random other
+token id, say `99`. That position has `loss_mask[2] = 0`, so:
+
+- `ell[2]` is computed as `-log p[2, 99]` instead of `-log p[2, 13]`.
+- The product `loss_mask[2] * ell[2]` is `0 * (anything) = 0`.
+- The numerator sum is unchanged. The denominator sum is unchanged.
+
+Result: `L_SFT ≈ 0.371`, identical. This is exactly what the unit test in Problem
+2.2 asserts. Try the flip in code, compute `(loss - loss_orig).abs().max()`, and the
+answer should be machine-zero.
+
+If the test fails, the most common cause is that the implementation accidentally
+divides by the unmasked count (`B * T`) instead of the mask sum, in which case the
+denominator changes when the labels do. Another cause is using `ignore_index=-100`
+elsewhere in the codepath, which lets framework code reinterpret labels and drift
+away from the explicit mask.
+
+### 4.8 Worked example: per-batch versus per-sequence denominator
+
+Two sequences in one batch. Lengths after shifting: 4 and 6. Loss masks (the part
+that supervises assistant content):
+
+```
+row 0:  loss_mask = [0, 0, 1, 1]                 # 2 supervised tokens
+row 1:  loss_mask = [0, 0, 0, 0, 1, 1]           # 2 supervised tokens
+
+per-token ell (already computed):
+row 0:  [_, _, 1.0, 0.5]
+row 1:  [_, _, _, _, 2.0, 1.0]
+```
+
+(Underscores are positions where `loss_mask = 0`. Their ell values do not matter.)
+
+Two ways to average:
+
+**Per-sequence then mean over rows.**
+
+    row 0 mean = (1.0 + 0.5) / 2 = 0.75
+    row 1 mean = (2.0 + 1.0) / 2 = 1.50
+    batch loss = (0.75 + 1.50) / 2 = 1.125
+
+**Per-batch (the InstructGPT convention).**
+
+    numerator   = 1.0 + 0.5 + 2.0 + 1.0 = 4.5
+    denominator = 2 + 2 = 4
+    batch loss  = 4.5 / 4 = 1.125
+
+Same answer here because both rows happen to have the same supervised count. Now
+imagine row 0's supervised count rises to 8 with most ells near zero, while row 1
+keeps its 2 ells near 1.5. Per-sequence averaging would give equal weight to both
+rows even though one has 4x more tokens; per-batch averaging weights each
+supervised token equally. Per-batch is what we want, because the model's
+representations are updated per-token, not per-row.
+
+Padding contributes 0 to the numerator (because `loss_mask = 0`) and 0 to the
+denominator. It is invisible to either calculation. The per-batch form is therefore
+robust to the shape of the batch.
 
 ---
 

--- a/notes/03-rm.md
+++ b/notes/03-rm.md
@@ -122,10 +122,28 @@ has only looked at positions `0, 1, ..., t`. Only the *last* position has seen t
 entire sequence. Earlier positions have missing information — they couldn't have
 judged the full response.
 
-Mean pooling can sound tempting, but it changes the meaning of the head. Earlier hidden
-states have not seen later response tokens, so averaging them asks many positions to judge
-partial answers. Last-token pooling is the clean causal choice: one scalar from the first
-state that has read the whole sequence.
+Mean pooling sounds tempting but changes the meaning of the head. Earlier hidden states
+have not seen later response tokens, so averaging them asks many positions to judge partial
+answers. Last-token pooling is the causal choice: one scalar from the first state that has
+read the whole sequence.
+
+#### Worked example: last-token pooling on a padded row
+
+Suppose the value head outputs `(B, T, 1)` per-position scalars. For one row of length 6
+(positions 0..3 are real, positions 4..5 are pad) the row's outputs are:
+
+```
+pos:           0     1     2     3     4     5
+piece:         A     4     .    /A   <pad> <pad>
+attn_mask:     1     1     1     1     0     0
+head[pos]:    0.5  -0.3   1.2   2.0   0.7  -0.4
+```
+
+The reward for this row is `head[3] = 2.0`. The last column (`head[5] = -0.4`) is a
+hidden state that has only seen padding inputs. Picking it produces a number with the
+right shape and a finite loss, but it is meaningless. The dataloader is responsible for
+reporting the last-real-token index per row; the loss is responsible for gathering at
+that index.
 
 ### 2.3 The loss
 
@@ -186,10 +204,26 @@ Why prefer this form? Two cases:
 
 In code, always write `F.softplus(r_r - r_c)`. Never `-log(sigmoid(r_c - r_r))`.
 
-Numerical stability is not optional here because reward scores can spread out during
-training. A naive formula may pass early tests and then produce `inf` or `nan` once the model
-gets confident. `softplus` is the same math written in a way floating-point arithmetic can
-survive.
+Numerical stability matters because reward scores can spread out during training. A naive
+formula may pass early tests and then produce `inf` or `nan` once the model gets confident.
+`softplus` is the same math written in a way floating-point arithmetic can survive.
+
+#### Worked example: softplus vs. naive form
+
+Suppose late in training the RM is very confident and outputs `r_c = 25.0`,
+`r_r = -25.0`, so `Delta = 50.0`.
+
+Naive form: `-log(sigmoid(50.0))`. In bf16, `sigmoid(50.0)` rounds to exactly 1.0,
+because `exp(-50)` is below the smallest representable bf16 normal. Then
+`log(1.0) = 0.0`, and the loss reports as exactly 0. The model believes it has
+finished training, but the *true* loss is `softplus(-50.0) = log(1 + exp(-50)) ≈
+1.93e-22`. Tiny but nonzero. Now flip the sign: `r_c = -25.0`, `r_r = 25.0`,
+`Delta = -50.0`. Naive form: `-log(sigmoid(-50.0))`. In bf16, `sigmoid(-50.0)`
+underflows to 0, and `-log(0)` becomes `+inf`. The training step explodes.
+
+`F.softplus(r_r - r_c)` handles both cases. For `Delta = +50` it returns
+`softplus(-50) ≈ 1.93e-22`. For `Delta = -50` it returns `softplus(+50) ≈ 50.0`.
+Same arithmetic, different code path, no underflow or overflow.
 
 ---
 
@@ -403,6 +437,57 @@ Clarity wins here because the preference loss is already conceptually new. A sha
 implementation introduces caching, sequence splicing, and careful gradient bookkeeping. None
 of that changes the Bradley-Terry objective, so it is the wrong place to spend complexity in
 a course repo.
+
+### 6.1 Worked example: a full preference-pair training step
+
+Same toy vocab as `00-data.md`. Imagine one preference example after tokenization
+(prompt + response, padded to length 7):
+
+```
+chosen tokens (length 6, last_real_idx_c = 5):
+  pos:        0   1   2   3   4   5   6
+  input_id:  10  11  13  14  16  17  15        # ...assistant\n  4  <|im_end|>
+  attn_mask:  1   1   1   1   1   1   0
+
+rejected tokens (length 7, last_real_idx_r = 6):
+  pos:        0   1   2   3   4   5   6
+  input_id:  10  11  13  14  16  19  15        # ...assistant\n  "wrong"  <|im_end|>
+  attn_mask:  1   1   1   1   1   1   1
+```
+
+(Token id 19 is a hypothetical "wrong" content token in this toy vocab.)
+
+Forward both sequences through the RM backbone and run the value head, getting
+per-position scalars of shape `(2, 7)`. Suppose the head produces:
+
+```
+chosen   head:  -0.10  0.05  0.20  0.15  0.40  1.80   ?      # ? on pad position
+rejected head:  -0.10  0.05  0.20  0.15  0.40 -0.20  0.30
+```
+
+Gather rewards at `last_real_idx`:
+
+    r_c = chosen_head[5] = 1.80
+    r_r = rejected_head[6] = 0.30
+
+Then:
+
+    Delta = r_c - r_r = 1.50
+    L_BT  = softplus(-Delta) = log(1 + exp(-1.50)) ≈ 0.201
+
+Gradients on the two scalars:
+
+    dL/dr_c = sigmoid(1.50) - 1 ≈ -0.182
+    dL/dr_r = 1 - sigmoid(1.50) ≈ +0.182
+
+After one optimizer step at lr 1.0 these would push `r_c` to about 1.98 and `r_r` to
+about 0.12. Backprop also flows through the head and into the backbone, so other
+preference examples in the same batch benefit too.
+
+Notice the gather-by-last-real-token: the chosen sequence's pad position at index 6
+is never consulted, and the rejected sequence's actual response uses a different
+final index from the chosen sequence's. Hard-coding `head[:, -1, 0]` would gather
+from a pad token in the chosen row and silently break training.
 
 ---
 

--- a/notes/04-ppo-gae.md
+++ b/notes/04-ppo-gae.md
@@ -20,9 +20,9 @@ loss will confidently push tokens in the wrong direction. That is why GAE gets i
 and its own tests.
 
 For every generated token, PPO needs to decide whether that exact token should become more
-likely next time. The advantage supplies the answer. Positive advantage means the token led
-to a better outcome than expected. Negative advantage means the token led to a worse outcome
-than expected. GAE turns delayed rewards, value predictions, and masks into those per-token
+likely next time. The advantage answers that. Positive advantage means the token led to a
+better outcome than expected. Negative advantage means the token led to a worse outcome than
+expected. GAE turns delayed rewards, value predictions, and masks into those per-token
 signals.
 
 ---
@@ -62,8 +62,7 @@ baseline.
 
 ### 1.1 A concrete rollout
 
-If this is your first time meeting RL, the abstractions above can feel slippery.
-Make it concrete. Suppose the prompt is:
+Suppose the prompt is:
 
     s_0 = "<|im_start|>user\nWhat is 2+2?<|im_end|>\n<|im_start|>assistant\n"
 
@@ -183,7 +182,7 @@ just the return-to-go $\hat G_t$ without changing the expectation. Done.
 
 Intuition for the end result: at each step, we nudge the model to make the action
 it took more (or less) likely, weighted by how good the future turned out to be.
-"Take what worked, do more of it" — gradient descent on trial and error.
+Trial and error, propagated through the chain rule.
 
 The theorem is powerful because it avoids differentiating through the sampling operation.
 Sampling a token is discrete, so ordinary backpropagation cannot pass through "which token
@@ -250,8 +249,8 @@ the variance of the estimator. The best choice is $b(s_t) = \mathbb{E}[\hat G_t 
 behind only the *action-specific* deviation from the average.
 
 We learn such a $b$ with a neural network and call it the **value function**
-$V(s_t)$. The difference between the observed return and the expected return is
-called the **advantage**:
+$V(s_t)$. The observed return minus this expected return is called the
+**advantage**:
 
 $$
 A_t  =  \hat G_t  -  V(s_t)
@@ -492,6 +491,108 @@ Result: `advantages = [1, 0, 0]`, `returns = [1, 0, 0]`.
 Add a second test with a pad token in the middle — your implementation should
 handle the `nonterm` mask correctly, zeroing out the bootstrap at the pad
 position.
+
+### 5.6 Worked example: GAE with a non-zero value baseline
+
+The all-zero example above hides what GAE actually does, because the value
+function is silent. Try a slightly more realistic case. Set `T = 3`,
+`gamma = 1`, `lambda = 0.95`, `nonterm = [1, 1, 1, 0]` (the position after
+the last real step is terminal). Per-token rewards and value estimates:
+
+    rewards = [0.0, 0.0, 1.0]
+    values  = [0.5, 0.3, 0.0]                 # V(s_T) = 0 by convention
+
+Step backward through `delta_t = r_t + gamma * V_{t+1} - V_t` and
+`A_t = delta_t + gamma * lambda * A_{t+1}`.
+
+    t = 2:
+        delta_2 = 1.0 + 1*0 - 0.0   = +1.0
+        A_2     = 1.0 + 0.95 * 0     = +1.0
+
+    t = 1:
+        delta_1 = 0.0 + 1*0.0 - 0.3 = -0.3
+        A_1     = -0.3 + 0.95 * 1.0  = +0.65
+
+    t = 0:
+        delta_0 = 0.0 + 1*0.3 - 0.5 = -0.2
+        A_0     = -0.2 + 0.95 * 0.65 = +0.4175
+
+So `advantages = [0.4175, 0.65, 1.0]` and `returns = A + V = [0.9175, 0.95, 1.0]`.
+
+Read out the structure: the value head expected to receive about `0.5` total
+return at `t=0` and `0.3` at `t=1`, but the actual outcome was a single unit of
+reward at `t=2`. GAE attributes most of the surprise to the last step (where
+the reward arrives) and bleeds a smaller share back to earlier steps,
+discounted by `(gamma * lambda)`.
+
+### 5.7 Worked example: lambda = 0 collapse to one-step TD
+
+Same rewards `[0, 0, 1]`, same `values = [0.5, 0.3, 0.0]`, same `gamma = 1`.
+Now `lambda = 0`. The recursion `A_t = delta_t + gamma * lambda * A_{t+1}`
+loses the future term entirely:
+
+    t = 2: A_2 = delta_2 = +1.0
+    t = 1: A_1 = delta_1 = -0.3
+    t = 0: A_0 = delta_0 = -0.2
+
+So `advantages = [-0.2, -0.3, 1.0]`. This is exactly the per-step TD error.
+Notice that earlier steps now get *negative* advantages, because the value
+head's optimistic predictions were wrong about *that* step in isolation, even
+though the trajectory eventually paid off. Low variance (each advantage is one
+TD error), high bias (we trust `V` to summarize the future).
+
+### 5.8 Worked example: lambda = 1 collapse to Monte Carlo
+
+Same setup, `lambda = 1`. The recursion becomes a plain backward sum of TD
+errors:
+
+    t = 2: A_2 = +1.0
+    t = 1: A_1 = -0.3 + 1.0 = +0.7
+    t = 0: A_0 = -0.2 + 0.7 = +0.5
+
+So `advantages = [0.5, 0.7, 1.0]`. Algebraically, `A_t = (sum_{k=t..T-1} r_k) -
+V(s_t)` here — Monte Carlo return minus the baseline. Higher variance because
+each advantage carries the full reward tail, but no systematic bias from `V`'s
+bootstraps.
+
+Compare the three rows:
+
+```
+lambda     A_0     A_1     A_2
+0.00     -0.20   -0.30   +1.00       # one-step TD
+0.95     +0.42   +0.65   +1.00       # standard PPO setting
+1.00     +0.50   +0.70   +1.00       # Monte Carlo
+```
+
+`lambda` is sliding between the all-bias and all-variance corners. PPO's
+preferred `0.95` lives close to the Monte Carlo end but inherits enough of `V`
+to dampen variance.
+
+### 5.9 Worked example: padded batch
+
+Two rollouts of different lengths, both padded to length 5. The mask
+`nonterm[t]` is `1` while inside the real episode and `0` afterwards.
+
+    row 0: actual length 3, nonterm = [1, 1, 1, 0, 0]
+    row 1: actual length 5, nonterm = [1, 1, 1, 1, 1]
+
+Per-row rewards and values:
+
+    row 0: rewards = [0, 0, 1, 0, 0]   values = [0.4, 0.2, 0.0, 0.0, 0.0]
+    row 1: rewards = [0, 0, 0, 0, 1]   values = [0.6, 0.4, 0.3, 0.1, 0.0]
+
+For row 0, the recursion only "pays attention" to positions 0..2. At `t=3`,
+`nonterm = 0`, so `delta_3 = r_3 + gamma * V_4 * 0 - V_3 = 0`, and `A_3 = 0 +
+gamma*lambda * A_4 * 0 = 0`. Same at `t=4`. Without the `nonterm` factor on
+the recursion's bootstrap term, advantages from positions 3 and 4 (which are
+just padding) would leak into position 2's computation. The mask zeroes them
+explicitly, so row 0's GAE advantages match what you'd compute on a
+length-3 sequence in isolation.
+
+This is the bug Problem 4.4's pad-in-the-middle test catches. If you forget
+the `nonterm` factor on the bootstrap, both rows still produce numbers, but
+row 0's advantages will be wrong in a way that depends on the (arbitrary)
+padding values.
 
 ---
 

--- a/notes/04-ppo-kl.md
+++ b/notes/04-ppo-kl.md
@@ -14,8 +14,9 @@ trustworthy guide.
 
 Think of the SFT model as the student's current style before RLHF starts. The reward model is
 the teacher's score. KL is the cost of changing style too aggressively while chasing that
-score. A little change is the point of training. A huge change is dangerous because the model
-may discover strange text that fools the grader but is worse for humans.
+score. Some change is the point of training; the KL term puts a price on each unit of change
+so the model does not race off and discover strange text that fools the grader without
+helping humans.
 
 By the end you should be able to:
 
@@ -29,12 +30,9 @@ By the end you should be able to:
 
 ## 0. A five-minute KL divergence primer
 
-Before we use KL divergence, we should know what it is. If you already do, skim
-this and keep going.
-
-KL divergence is a number that measures **how different two probability
-distributions are**, from the point of view of one of them. For two distributions
-$P$ and $Q$ over the same set of outcomes, the KL divergence from $P$ to $Q$ is:
+KL divergence is a number that measures how different two probability distributions are,
+from the point of view of one of them. For two distributions $P$ and $Q$ over the same
+set of outcomes, the KL divergence from $P$ to $Q$ is:
 
 $$
 \mathrm{KL}(P \| Q) = \sum_x P(x) \cdot \log \frac{P(x)}{Q(x)}
@@ -193,8 +191,8 @@ But we don't have the full distribution or an exact expectation. We have exactly
 one sample $a_t$ drawn from $\pi_\theta$. What's our best single-sample estimate?
 
 This sample-based setting is why the estimators below can look strange. A true KL divergence
-is nonnegative, but a one-sample estimate of it does not have to be. The estimator only needs
-to average to the right value over many samples. In training logs, however, negative
+is nonnegative, while a one-sample estimate of it does not have to be. The estimator only
+needs to average to the right value over many samples. In training logs, negative
 single-sample KL values are visually confusing, which motivates the separate diagnostic
 estimator.
 
@@ -317,8 +315,117 @@ In this repo: `kl_k1` goes into `shape_reward`; `kl_k3` is computed for the CSV
 log but not used in gradients.
 
 That separation is intentional. The training reward should match the algorithm you are
-studying. The logging metric should be easy to read. Those are related goals, but they are
-not identical goals.
+studying. The logging metric should be easy to read. Those goals overlap but are not the
+same.
+
+### 3.5 Worked example: comparing k_1, k_2, k_3 on the same samples
+
+Pick two fixed three-class distributions:
+
+    pi      = (0.5, 0.3, 0.2)         # current policy
+    pi_ref  = (0.4, 0.4, 0.2)         # reference (frozen)
+
+Analytic forward KL (computed as a check; PPO never actually has it):
+
+    KL(pi || pi_ref) = 0.5*log(0.5/0.4) + 0.3*log(0.3/0.4) + 0.2*log(0.2/0.2)
+                     ≈ 0.0247 nats
+
+Now imagine 5 single-token samples drawn from `pi`. For each sample we record
+the action `a`, then compute `L = log pi(a) - log pi_ref(a)` and the three
+estimators. Suppose the samples are `a = 0, 0, 1, 0, 2` (which is plausible
+under `pi`, since class 0 is most likely).
+
+```
+sample  a    pi(a)  pi_ref(a)   L = log(pi/pi_ref)   k_1     k_2 = 0.5*L^2   inv_rho = pi_ref/pi   k_3 = inv_rho - 1 + L
+1       0    0.5    0.4         +0.2231              +0.2231  +0.0249         0.800                 -0.200 + 0.2231 ≈ +0.0231
+2       0    0.5    0.4         +0.2231              +0.2231  +0.0249         0.800                 +0.0231
+3       1    0.3    0.4         -0.2877              -0.2877  +0.0414         1.333                 +0.333 - 0.2877 ≈ +0.0457
+4       0    0.5    0.4         +0.2231              +0.2231  +0.0249         0.800                 +0.0231
+5       2    0.2    0.2          0.0                  0.0      0.0            1.000                  0.0
+```
+
+Sample averages:
+
+    mean k_1 ≈ +0.0769          # signed; matches forward KL only in expectation
+    mean k_2 ≈ +0.0232          # always non-negative; biased estimator of KL
+    mean k_3 ≈ +0.0190          # always non-negative; unbiased for forward KL
+
+`k_1` overshoots the true 0.0247 here on this small sample because it weighted
+the three positive samples more than the one negative. Over many samples, both
+`k_1` and `k_3` will average to ~0.0247. `k_2` measures something different
+(the squared log-ratio); it happens to be close in this example, but in
+general it does not match KL.
+
+Notice sample 3: `k_1 = -0.2877` (negative, weird-looking for a divergence),
+while `k_3 = +0.0457` (always non-negative). This is the variance reduction in
+action: `k_3` adds the `(inv_rho - 1)` correction, which has expected value 0
+under `pi` but pulls extreme single-sample values back toward 0.
+
+### 3.6 Worked example: per-token KL and reward shaping
+
+Take a 5-token response with `beta = 0.02` and terminal reward
+`r_RM = +1.5`. Suppose during rollout we recorded the per-token current-policy
+log-probs and the reference's log-probs:
+
+```
+pos:               0      1      2      3      4
+piece:             "The"  "ans"  "wer"  "is"   "<|im_end|>"
+logprobs (theta): -1.20  -1.50  -2.00  -1.10  -0.30
+logprobs (ref):   -1.50  -1.40  -2.20  -1.30  -0.50
+response_mask:    1      1      1      1      1
+last_idx:                                       <-- terminal reward injected here
+```
+
+Per-token KL via `k_1`:
+
+    KL_k1[t] = logprobs[t] - ref_logprobs[t]
+             = +0.30, -0.10, +0.20, +0.20, +0.20
+
+Per-token reward via the shaping formula:
+
+    r[t] = -beta * KL_k1[t] * response_mask[t] + r_RM * (t == last_idx)
+
+```
+pos:        0       1       2       3       4
+-beta*KL: -0.0060 +0.0020 -0.0040 -0.0040 -0.0040
++r_RM*1{t==4}: 0     0       0       0     +1.5000
+r[t]:    -0.0060 +0.0020 -0.0040 -0.0040 +1.4960
+```
+
+Read the row out loud. Most positions get a tiny negative reward (the policy
+moved slightly away from the reference and is paying KL). Position 1 has a
+small positive reward (the policy moved *toward* the reference there — a
+single-sample artifact, since `k_1` is signed). The terminal token carries the
+RM's verdict on the whole response, lightly attenuated by its own KL term.
+
+GAE will then propagate that final +1.5 backward through the response,
+discounted by `(gamma * lambda)`, while keeping the per-position KL costs
+local. That is what makes the policy learn "stay close to ref except where
+moving away clearly improved the eventual reward."
+
+### 3.7 Worked example: edge cases for shaping
+
+Two limits that are worth checking explicitly.
+
+**`beta = 0`.** Plug into the shaping formula:
+
+    r[t] = -0 * KL_k1[t] + r_RM * (t == last_idx)
+         = r_RM * (t == last_idx)
+
+So every position is 0 except the last, which is the terminal RM reward. No
+token-level pressure to stay near `pi_ref`. PPO will discover the highest-RM
+output regardless of how strange. This is the unit test for `beta = 0`:
+shape_reward should reduce to a single nonzero entry per row.
+
+**`pi = pi_ref` exactly.** Then `logprobs == ref_logprobs` at every position,
+so `KL_k1[t] = 0` for all `t`. Shaped reward is again purely terminal:
+
+    r[t] = r_RM * (t == last_idx)
+
+This case happens by construction in the very first PPO iteration after
+loading both policy and reference from `sft.pt`. The KL contribution is
+exactly zero on the first batch, and the only signal driving the policy is
+the terminal RM reward. Useful sanity check during debugging.
 
 ---
 

--- a/notes/04-ppo-policy.md
+++ b/notes/04-ppo-policy.md
@@ -149,11 +149,11 @@ Or in code-style:
 
 where `N` is the count of masked-in response tokens.
 
-Read the `min` carefully: we take the **smaller** (more pessimistic) of the two
-surrogates, then *negate* the whole thing for the loss. Equivalently: inside the
-objective (before the negation), we take the *minimum* of `surr1` and `surr2`,
-i.e. the less favorable one. This setup prevents the policy from being rewarded for running
-the ratio far outside `[1 - eps, 1 + eps]` in the direction of increasing the objective.
+The `min` takes the smaller (more pessimistic) of the two surrogates, and the negation in
+front turns it into a loss. Inside the objective (before negation) we take the minimum of
+`surr1` and `surr2`, i.e. the less favorable one. This setup prevents the policy from being
+rewarded for running the ratio far outside `[1 - eps, 1 + eps]` in the direction of
+increasing the objective.
 
 The negation is a common source of confusion. PPO papers usually describe maximizing the
 surrogate objective. PyTorch optimizers usually minimize a loss. This repo writes the loss as
@@ -182,6 +182,27 @@ flowing. For positive advantages, an extreme improvement means the sampled token
 more likely. For negative advantages, an extreme improvement means the sampled token became
 much less likely. The table below writes out those cases.
 
+Two more numerical cases finish the picture. Same `epsilon = 0.2`, clip range `[0.8, 1.2]`:
+
+- **Token C (good action moving the wrong way).** Advantage `A = +1`, ratio
+  `rho = 0.5`. The policy made a good action *less* likely than at rollout. Compute:
+  `surr1 = 0.5`, `surr2 = clip(0.5, 0.8, 1.2) * 1 = 0.8`. `min = 0.5`. Loss
+  `= -0.5`. The clip does not fire, because firing it would replace the smaller
+  unclipped value (`0.5`) with the larger clipped value (`0.8`) — the wrong direction
+  for a "pessimistic" choice. Gradient through `rho` is `-A * rho = -0.5` (nonzero),
+  which after one optimizer step makes the action more likely again. Good.
+- **Token D (bad action moving the wrong way).** Advantage `A = -1`, ratio
+  `rho = 2.0`. The policy made a bad action *more* likely than at rollout. Compute:
+  `surr1 = -2.0`, `surr2 = clip(2.0, 0.8, 1.2) * (-1) = -1.2`. `min = -2.0`. Loss
+  `= +2.0`. The clip does not fire here either: replacing `-2.0` with `-1.2` would
+  *raise* the inner objective, the opposite of pessimistic. Gradient through `rho`
+  is `-A * rho = +2.0` (nonzero, large), pushing this bad action's probability back
+  down. The clip never spares the policy from correcting a bad move.
+
+Same pattern, four cases. Whenever the ratio is on the "fighting the advantage"
+side of 1 (good action being made less likely, or bad action being made more
+likely), the clip stays out of the way and the gradient corrects course.
+
 ### 2.2 What "pessimistic" means, case by case
 
 There are essentially four cases based on the sign of `A` and where `rho` sits.
@@ -197,11 +218,10 @@ Here's a compact table. "Gradient" means gradient of `L_clip_t` with respect to
 | A < 0 | rho < 1 - eps | `surr2` | `surr2` | **0** (clipped) |
 | A < 0 | rho > 1 + eps | `surr1` | `surr1` | `-A * rho` |
 
-The pattern: **the clip only fires when firing it would pull the objective back**.
-That is, when the policy is already moving in a good direction and has gone "too
-far". When the policy is moving in the wrong direction (ratio on the wrong side
-of 1), the clip *doesn't* fire, so we still get gradient signal pushing the ratio
-back toward 1.
+The clip only fires when firing it would pull the objective back. That happens when the
+policy is already moving in a good direction and has gone too far. When the policy is moving
+in the wrong direction (ratio on the wrong side of 1), the clip does not fire, so the
+gradient still pushes the ratio back toward 1.
 
 ### 2.3 Deriving the piecewise gradient
 
@@ -380,6 +400,52 @@ Gradient-check the whole thing at fp64 in Problem 4.6. Include a case where
 `V_theta` is far from both `V_old` and `R` — make sure the gradient matches what
 you'd compute by hand for the selected branch.
 
+### 3.5 Worked example: clipped value loss
+
+Set `eps_v = 0.2`. One token at one position:
+
+    V_old = 0.5
+    V_theta = 1.5
+    R = 0.7
+
+Compute both branches:
+
+    V_clipped = V_old + clip(V_theta - V_old, -eps_v, +eps_v)
+              = 0.5 + clip(1.0, -0.2, +0.2)
+              = 0.5 + 0.2 = 0.7
+
+    branch_unclipped = (V_theta - R)^2     = (1.5 - 0.7)^2 = 0.64
+    branch_clipped   = (V_clipped - R)^2   = (0.7 - 0.7)^2 = 0.00
+
+    per_tok_loss = 0.5 * max(0.64, 0.00) = 0.32
+
+`max` picks the unclipped branch. Gradient through `V_theta`:
+
+    d(per_tok_loss) / dV_theta = (V_theta - R) = +0.8
+
+After one optimizer step at lr 1.0, `V_theta` moves to `0.7`, exactly matching
+`R`. If we had ignored the clip and just used MSE, `V_theta` would still have
+moved to `0.7` after one step on this single example — same direction, same
+magnitude, because the unclipped branch was selected. The clip only matters when
+its branch wins the `max`.
+
+Now flip: same `V_old = 0.5`, `R = 0.7`, but `V_theta = 0.55`. Then
+`V_clipped = 0.55` (clip inactive), both branches are `(0.55 - 0.7)^2 = 0.0225`,
+the `max` is the same number, and gradient is `(V_theta - R) = -0.15`. Plain
+MSE behavior, as expected near the on-policy limit.
+
+### 3.6 Why the clip helps early in training
+
+Suppose the value head is fresh and outputs `V_old = 0.0` at every position.
+The first batch returns `R` values around `5.0` (the reward model produced
+larger numbers than the value head expected). Without clipping, the value
+gradient pushes every position's `V_theta` toward `5.0` in one step, which
+overshoots and feeds garbage advantages into the next iteration. With
+`eps_v = 0.2`, no single step can move `V_theta` more than `0.2` away from
+`V_old`, so the value head learns gradually and the policy never sees a
+single iteration of severely miscalibrated advantages. The cost is slower
+value learning; the benefit is that the policy stops diverging.
+
 ---
 
 ## 4. Entropy bonus (Problem 4.7)
@@ -507,6 +573,46 @@ pushes that dominant logit down, spreading probability mass out.
 Gradient-check the entropy at fp64 on a small logits tensor. Apply the mask,
 verify that flipping logits *outside* the mask doesn't change the computed
 entropy or its gradient.
+
+### 4.6 Worked example: entropy on a 3-class softmax
+
+Logits `z = (1, 0, -1)`. Softmax:
+
+    exp(1) ≈ 2.718,  exp(0) = 1.000,  exp(-1) ≈ 0.368
+    Z = 4.086
+    p = (0.665, 0.245, 0.090)
+
+Entropy:
+
+    H = -sum p * log p
+      = -(0.665 * (-0.408) + 0.245 * (-1.407) + 0.090 * (-2.408))
+      ≈ 0.272 + 0.345 + 0.217
+      ≈ 0.834 nats
+
+Gradient `dH/dz = -p * (log p + H)`:
+
+    log p ≈ (-0.408, -1.407, -2.408)
+    log p + H ≈ ( 0.426, -0.573, -1.574)
+    dH/dz ≈ -p * (log p + H)
+          ≈ -(0.665, 0.245, 0.090) * (0.426, -0.573, -1.574)
+          ≈ (-0.283, +0.140, +0.142)
+
+Read the signs. The dominant logit (index 0) has `dH/dz < 0`, so increasing it
+*decreases* entropy. The two smaller logits have `dH/dz > 0`, so raising them
+*increases* entropy by spreading mass. The PPO loss contains `-c_entropy * H`,
+so gradient descent on the loss *adds* `c_entropy * dH/dz` to each logit's
+update. With `c_entropy > 0` that pushes the dominant logit down and the small
+logits up, smoothing the distribution. With `c_entropy = 0` (our default) the
+term contributes nothing.
+
+Two sanity-check limits:
+
+- Uniform `p = (1/3, 1/3, 1/3)`: `log p = -log 3` everywhere, `H = log 3`, so
+  `log p + H = 0` for every class and `dH/dz = 0`. Uniform is the entropy maximum.
+- Near-deterministic `p ≈ (0.999, 0.0005, 0.0005)`: `H ≈ 0.008`, the small classes
+  have `log p ≈ -7.6`, `log p + H ≈ -7.59`, and `dH/dz` for those classes is large
+  positive (about `+0.0038`). Tiny in absolute scale because `p` is tiny, but
+  enough to nudge the distribution back toward something less peaky.
 
 ---
 

--- a/notes/05-ppo.md
+++ b/notes/05-ppo.md
@@ -99,6 +99,46 @@ through the reference or reward model, missing `torch.no_grad()` in rollout, or 
 logit tensors in the rollout buffer. Rollouts should store gathered log-probs, not
 vocabulary-sized distributions for every token.
 
+#### Worked example: a memory-budget walk-through
+
+Plug actual numbers into the rough count, for `gpt2-small` with the default
+PPO config (rollout batch 64, response len 256, n_embd 768).
+
+    weights, bf16, 4 models = 4 * 124e6 * 2 bytes = 992 MB
+    fp32 master copy of trainable params (124M policy + 769 value head)
+                            ≈ 124e6 * 4 bytes ≈ 496 MB
+    AdamW first moment, fp32 = 124e6 * 4 ≈ 496 MB
+    AdamW second moment, fp32 = 124e6 * 4 ≈ 496 MB
+    --- subtotal weights + optimizer state ≈ 2480 MB ≈ 2.5 GB
+
+    rollout buffers, fp32:
+      logprobs_old:  (64, 256)        =  16 384 floats ≈ 64 KB
+      values_old:    (64, 256)        =  16 384 floats ≈ 64 KB
+      ref_logprobs:  (64, 256)        =  16 384 floats ≈ 64 KB
+      advantages:    (64, 256)        =  16 384 floats ≈ 64 KB
+      returns:       (64, 256)        =  16 384 floats ≈ 64 KB
+      response_mask: (64, 256)        =  16 384 floats ≈ 64 KB
+      response_ids:  (64, 256), int64 =  16 384 longs  ≈ 128 KB
+    --- rollout buffers ≈ 0.5 MB total
+
+    activations under gradient checkpointing:
+      one trainable forward+backward at batch 4 micro, seq 512 ≈ 3-6 GB
+      depending on how many layer outputs you cache vs. recompute
+
+    CUDA workspace + cuBLAS scratch ≈ 1-2 GB
+
+    grand total ≈ 7-10 GB
+
+Two surprises worth noticing:
+
+- The rollout buffers are tiny next to the optimizer state. Storing a full
+  `(B, T, V)` logit tensor instead of a gathered `(B, T)` log-prob tensor would
+  add `64 * 256 * 50257 * 4 bytes ≈ 3.3 GB` per buffer. That is the bug the
+  shape hint above is meant to prevent.
+- Activations dominate the variable part of the budget. If you OOM, the
+  cheapest knob is shorter `response_len` or smaller per-step batch — both
+  cut activation memory linearly, while the optimizer-state line is fixed.
+
 ### 2.2 gpt2-medium (355M) is tight
 
 Weights and optimizer state both scale roughly linearly, so medium is about 3x
@@ -182,6 +222,51 @@ A fourth practical invariant: frozen models stay frozen. The reference and rewar
 should be in eval mode, under `torch.no_grad()`, and have `requires_grad_(False)`. Any
 optimizer parameter group that accidentally includes them is both a memory bug and an
 algorithm bug.
+
+#### Worked example: tensor shapes for one PPO iteration
+
+Concrete sizes for the default config (`B = 4` for the inner-loop micro-batch,
+prompt_len ≤ 64, response_len = 32, n_embd = 768, vocab = 50257). The rollout
+phase produces tensors at the *rollout* batch size (64); the inner loop slices
+them into the micro-batch size (4).
+
+```
+rollout phase, no grad:
+  prompts (left-padded):   (64,  64)            int64
+  response_ids:            (64,  32)            int64
+  attention_mask:          (64,  96)            bool        # prompt + response
+  response_mask:           (64,  32)            float32     # 1 on real response tokens
+  logprobs_old:            (64,  32)            float32     # gathered, not (B, T, V)
+  values_old:              (64,  32)            float32
+  ref_logprobs:            (64,  32)            float32
+  rm_rewards:              (64,)                float32     # one scalar per row
+  per_tok_r:               (64,  32)            float32
+  advantages:              (64,  32)            float32     # normalized
+  returns:                 (64,  32)            float32
+
+inner-loop micro-batch (4 rows):
+  mb.prompts:              (4,   64)            int64
+  mb.response_ids:         (4,   32)            int64
+  mb.logprobs_old:         (4,   32)            float32
+  mb.values_old:           (4,   32)            float32
+  mb.advantages:           (4,   32)            float32
+  mb.returns:              (4,   32)            float32
+  mb.mask:                 (4,   32)            float32
+
+  forward pass:
+    logits_new:            (4,   96, 50257)     bf16        # full sequence
+    logprobs_new:          (4,   32)            bf16        # gathered at response positions only
+    values_new:            (4,   96)            bf16        # then sliced to (4, 32)
+```
+
+Two things to verify in code:
+
+- `logprobs_old` and `logprobs_new` have the same shape `(mb_B, response_len)`,
+  not `(mb_B, prompt_len + response_len)`. Aligning prompt log-probs with
+  response log-probs is the most common off-by-one source.
+- `logits_new` has the full vocab dimension `(B, T, V)` *only* during the
+  forward pass; immediately gather to `(B, T)` and discard the big tensor
+  before backprop, otherwise activations balloon.
 
 ---
 
@@ -270,6 +355,45 @@ around 20%, grad norm stable, tokens/sec stable.
 When a run fails, change one knob at a time. PPO metrics are coupled: lowering LR can reduce
 KL, clip fraction, and reward growth all at once. If you change LR, beta, K, and response
 length together, you will not know which change helped.
+
+### 5.3 Worked example: healthy vs. reward-hacking log rows
+
+Two CSV rows, both real-shaped, both from the same training script. Read the
+columns top to bottom and decide what story each row is telling.
+
+**Healthy iteration (iter = 80):**
+
+```
+iter,  mean_rm_reward,  mean_kl_k3,  L_pi,    L_v,    entropy,  clip_fraction,  grad_norm,  tok/s,  resp_len
+80,    +0.42,           0.61,        -0.018,  0.143,  2.71,     0.18,           0.62,       1180,   91.4
+```
+
+Reward is climbing slowly. KL is small but positive (about 0.6 nats per
+response is well within the soft trust region for `beta = 0.02`). Policy loss
+hovers near zero, value loss is decreasing run-over-run, entropy is drifting
+down from the SFT baseline of around 3.0, clip fraction is in the healthy
+10–30% band, gradient norm is well under the clip threshold of 1.0, and
+tokens/sec is steady. Average response length has risen modestly.
+
+**Reward hacking (iter = 80, different run):**
+
+```
+iter,  mean_rm_reward,  mean_kl_k3,  L_pi,    L_v,    entropy,  clip_fraction,  grad_norm,  tok/s,  resp_len
+80,    +1.85,           4.20,        -0.105,  0.880,  1.42,     0.51,           1.00,       1170,   232.7
+```
+
+Reward has shot up four-fold. KL has crossed 4 nats per response and is
+trending up faster than reward. Entropy collapsed from ~2.7 to ~1.4. Clip
+fraction is over 50%, which means most tokens land outside `[1 - eps, 1 +
+eps]` per inner step. Gradient norm is pinned at the clip ceiling (1.0
+exactly), suggesting most batches saturate the clip. Average response length
+exploded from ~90 to ~233. This is the classic length-bias plus reward-hack
+pattern: the policy is producing long, high-reward, low-entropy answers that
+look nothing like SFT.
+
+The fix list, top to bottom: raise `beta` (0.02 → 0.06), then lower the
+policy learning rate by 3x, then check the RM for a length-vs-reward
+correlation on a held-out batch. Make one change per run.
 
 ---
 

--- a/notes/06-eval.md
+++ b/notes/06-eval.md
@@ -11,15 +11,15 @@ at this stage — the theory is all behind you. This note is about:
 
 Fill this file in with your actual outputs as you run the problems.
 
-Evaluation is where you stop optimizing proxies and look at behavior. Training loss, reward
-model score, KL, and win-rate are all useful, but none of them substitutes for reading the
-model's answers. The final question is not "did a scalar improve?" It is "does this assistant
-follow instructions better in ways a human can recognize?"
+Evaluation is where you stop optimizing proxies and read what the model actually says.
+Training loss, reward model score, KL, and win-rate are useful, but none of them substitutes
+for the question a human cares about: does this assistant follow instructions better than
+the previous version?
 
-Read evaluation by looking at behavior, not only metrics. Base GPT-2 should reveal why
-instruction tuning is needed. SFT should show what imitation buys you. RLHF should show
-whether optimizing the learned preference signal improved answers beyond imitation or mostly
-changed their style. The side-by-side table is where those differences become visible.
+Base GPT-2 should reveal why instruction tuning is needed. SFT should show what imitation
+buys. RLHF should show whether optimizing the learned preference signal improved answers
+beyond imitation or mostly changed their style. The side-by-side table is where those
+differences become visible.
 
 ---
 
@@ -60,9 +60,9 @@ For a more deterministic comparison you can also generate with temperature 0
 (greedy). More boring to read, but removes all sampling noise so the differences
 are fully attributable to the model weights.
 
-A good practice is to run both: greedy for a clean model-to-model comparison, and sampled
-generation for a more realistic view of behavior. Greedy outputs can hide diversity problems;
-sampled outputs can hide regressions behind randomness. Together they give a better picture.
+Running both is useful: greedy for a clean model-to-model comparison, sampled generation
+for a more realistic view of behavior. Greedy outputs can hide diversity problems. Sampled
+outputs can hide regressions behind randomness. Together they give a better picture.
 
 ### 1.3 Format
 
@@ -76,9 +76,43 @@ A markdown table like:
 
 Paste it under a "Results" section in this file.
 
-When the table is large, readability matters. Trim extremely long responses, but do not trim
-away the failure. If a model rambles, show enough rambling that the failure mode is visible.
-If a model never emits `<|im_end|>`, note that explicitly.
+### 1.4 Worked example: a 5-row toy table
+
+What the table should look like, with hand-written outputs that illustrate the kinds
+of differences you should be looking for. These are not real generations — they are
+caricatures of the failure modes each model tends to show.
+
+```
+| # | Prompt                              | Base                                                      | SFT                                            | RLHF                                       |
+|---|-------------------------------------|-----------------------------------------------------------|------------------------------------------------|--------------------------------------------|
+| 1 | What is 2+2?                        | What is 2+2? What is 3+3? What is 4+4? ...                | 4.                                             | 4.                                         |
+| 2 | Capital of Kenya?                   | The capital of Kenya is a country in East Africa...       | The capital of Kenya is Nairobi.               | Nairobi.                                   |
+| 3 | List 3 prime numbers.               | Prime numbers are numbers that are only divisible by ...  | 1. 2  2. 3  3. 5                               | 2, 3, 5.                                   |
+| 4 | I feel anxious about a deadline.    | Human: I also feel anxious. Assistant: Me too. Human: ... | I'm sorry to hear that. Try breaking it down.  | That sounds stressful. Two things help...  |
+| 5 | Write a JSON object with one key.   | { "key": "value", "key2": "value2", "key3": ...           | { "key": "value" }                             | { "key": "value" }                         |
+```
+
+What to read out of this:
+
+- **Row 1**: base loops; SFT and RLHF answer once. SFT and RLHF agree.
+- **Row 2**: base rambles around the answer; SFT answers in a full sentence; RLHF
+  is more concise. Concise is not always better — it depends on the prompt.
+- **Row 3**: SFT picked up a numbered-list pattern from training. RLHF often
+  prefers shorter formats because they are slightly higher reward on average.
+- **Row 4**: base hallucinates a multi-turn dialogue (the classic SFT-fixes-it
+  failure mode). SFT and RLHF stay in role.
+- **Row 5**: format-sensitive. Base often fails to terminate JSON. SFT and RLHF
+  emit valid JSON. Watch for RLHF that adds polite preamble before the JSON; that
+  is a common reward-hacking pattern that breaks downstream parsing.
+
+If your real table looks nothing like this — for example, RLHF rambles like base, or
+SFT and RLHF are indistinguishable on every prompt — that is information. RLHF that
+mirrors SFT means the policy did not move; RLHF that mirrors base means the policy
+moved away from SFT in the wrong direction.
+
+Trim extremely long responses, but do not trim away the failure. If a model rambles, show
+enough rambling that the failure mode is visible. If a model never emits `<|im_end|>`, note
+that explicitly.
 
 ---
 
@@ -118,10 +152,9 @@ SFT and the run failed. Likely reasons:
 - Too few PPO iterations.
 - Reward hacking that isn't visible on these particular prompts.
 
-Treat 20 prompts as a smoke test, not a publication-grade benchmark. A 55% win-rate on 20
-items is only a weak signal, but it is enough to catch obvious regressions and to force
-manual inspection. If you want stronger evidence, increase the prompt count and keep the
-annotation protocol blinded.
+Treat 20 prompts as a smoke test. A 55% win-rate on 20 items is a weak signal, enough to
+catch obvious regressions and force manual inspection. For stronger evidence, increase the
+prompt count and keep the annotation protocol blinded.
 
 ### 2.4 If RLHF didn't win
 
@@ -133,9 +166,43 @@ Don't paper over it. Write down honestly:
 
 Then actually change it and try again, if you want to.
 
-The most useful failed evaluation is specific. "RLHF lost" is not specific. "RLHF gives
-longer answers that score well but ignore requested JSON formatting" is specific, and it
-points toward checking reward length bias and format-sensitive prompts.
+"RLHF lost" tells you nothing. "RLHF gives longer answers that score well but ignore
+requested JSON formatting" points you straight at checking reward length bias and
+format-sensitive prompts. Make the failed evaluation specific.
+
+### 2.5 Worked example: a 20-row tally
+
+A filled-in tally for 20 prompts where RLHF wins with margin to spare. Each row
+records your blinded judgement after both passes (forward and reversed order) have
+been collected and reconciled.
+
+```
+prompt:  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20
+result:  R  R  T  R  S  R  R  T  R  R  S  R  R  R  T  R  S  R  R  R
+```
+
+Counts: `R` (RLHF win) = 13, `T` (tie) = 3, `S` (SFT win) = 4. Plug into the formula:
+
+    win_rate_RLHF = (13 + 0.5 * 3) / 20 = 14.5 / 20 = 0.725
+
+That clears the 0.55 target. Now do the diagnostic pass: read every row where SFT won
+and look for a pattern. In this hypothetical, three of the four SFT wins were prompts
+that asked for a list, and on those rows the RLHF response was shorter and dropped one
+required item. That is information: your RLHF policy may be over-compressing list
+outputs, possibly because the RM has a slight bias against long responses on chatty
+prompts. Note this in `notes/06-eval.md` and either accept it, raise `beta`, or
+retrain the RM with explicit length-balanced pairs.
+
+A second hypothetical, less rosy:
+
+```
+prompt:  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20
+result:  R  S  T  S  S  R  T  S  R  S  R  S  T  S  R  S  S  T  S  R
+```
+
+Counts: `R` = 5, `T` = 4, `S` = 11. Win rate = `(5 + 2) / 20 = 0.35`. RLHF lost. Read
+section 2.4 of this note again, then start with the most likely cause for your run
+(usually too-large `beta`, weak RM, or too few PPO outer iterations).
 
 ---
 
@@ -143,9 +210,9 @@ points toward checking reward length bias and format-sensitive prompts.
 
 One page, answering these six questions directly.
 
-The retrospective should be technical, not sentimental. Name the bug, the symptom, the test
-that caught it, and the fix. The point is to make the next RLHF implementation easier because
-you have a written catalog of failure modes.
+Keep the retrospective technical. Name the bug, the symptom, the test that caught it, and the
+fix. The point is to make the next RLHF implementation easier because you have a written
+catalog of failure modes.
 
 ### 3.1 What was the hardest part?
 
@@ -160,9 +227,8 @@ Count your commits and your notes. The gap between "how hard I thought it would
 be" and "how long it actually took" is diagnostic. Almost always, the answer
 reveals where your mental model was the weakest.
 
-This is worth writing down because time spent is a better teacher than confidence. If a
-concept felt easy but consumed two days, that concept deserves another derivation or a better
-unit test.
+Time spent is a better teacher than confidence. If a concept felt easy but consumed two days,
+that concept deserves another derivation or a better unit test.
 
 ### 3.3 Which gradient check saved you?
 
@@ -192,13 +258,50 @@ appear when you build RLHF from scratch, and how you learned to catch them.
 
 ### 3.6 What did you not understand before, and what do you understand now?
 
-Pick one thing. Write two paragraphs. "I used to think X; now I think Y." If you
-can't think of one, you didn't learn anything and you should redo the course.
-But you *will* find one.
+Pick one thing. Write two paragraphs in the form "I used to think X; now I think Y." If you
+can't find one, redo the course. But you *will* find one.
 
 Good examples are concrete: "I used to think PPO clipping just limited ratios; now I
 understand it clips only advantage-improving moves." Or: "I used to think masking was a
 data-loader detail; now I understand it defines the actual supervised objective."
+
+### 3.7 Worked example: a filled retrospective
+
+Use this as a calibration target for the level of specificity expected. The numbers
+and bugs below are illustrative, not from a real run.
+
+> **Hardest part.** Aligning `logprobs_old` and `logprobs_new` in the PPO inner loop.
+> The shift between input positions and predicted-next-token positions is one offset;
+> the shift between prompt+response tokens and response-only positions is another.
+> I had to draw both alignments on paper before the per-token KL plot stopped looking
+> like garbage.
+>
+> **Where I actually spent the most time.** The reward model. Pairwise accuracy was
+> stuck at 53% for three days. The cause was a tokenizer mismatch: the chat template
+> in `data_hh.py` was using literal `<|im_end|>` text but the RM dataloader had been
+> ported from an earlier version that stripped trailing whitespace, so the last-token
+> index pointed one position too far left. After fixing it, accuracy jumped to 67%
+> in the next training run.
+>
+> **Gradient check that saved me.** The "flip a masked token, loss unchanged" test in
+> `tests/test_grad_sft.py`. It caught a bug where the SFT mask was being applied to
+> `input_ids` instead of `labels`, which meant the model was being graded on the
+> token *before* the assistant content. Loss numbers looked sensible; generations
+> were nonsensical until I fixed it.
+>
+> **What I would do differently.** Initialize the value head from a small random
+> normal instead of zeros. Zero-init meant the first 50 PPO iterations had near-zero
+> advantages, which slowed early learning more than I expected.
+>
+> **What I got wrong and fixed.** (1) SFT mask off by one — see above. (2) GAE
+> applied without `nonterm` mask on padded rows, which leaked future reward across
+> rows that finished early. (3) Used `min` where the value loss needed `max`,
+> caught by the gradient-check on the clipped branch.
+>
+> **What I understand now that I did not before.** "I used to think PPO's clip was
+> a regularizer; now I think of it as a piecewise gradient that turns off whenever
+> firing it would soften a self-correcting move. The clip is asymmetric in a way
+> that only makes sense once you write the per-token gradient table by hand."
 
 ---
 
@@ -208,9 +311,8 @@ data-loader detail; now I understand it defines the actual supervised objective.
 - The 20-row win-rate tally from 6.2 with your scoring notes.
 - The retrospective from 6.3.
 
-This is the last file in the curriculum. When it's complete, the course is
-complete.
+This is the last file in the curriculum. When it's complete, the course is complete.
 
-At that point, the notes should be useful without the code open. A future reader should be
-able to understand what was trained, how it was evaluated, which results were convincing, and
-which parts still need work.
+The notes should then be useful without the code open. A future reader should be able to
+understand what was trained, how it was evaluated, which results were convincing, and which
+parts still need work.


### PR DESCRIPTION
Two passes per note. First pass tightens prose to the learner's voice:
removes negative-parallelism patterns ("not X, it's Y"), drops compulsive
transitions and mirror sentences, and strips importance puffery while
preserving analogies that serve as additional concrete examples.

Second pass adds worked examples wherever the math-to-tokens connection
was thin. New examples include: tokenized chat templates with aligned
loss masks (00-data, 02-sft), softplus stability and full preference-pair
pipelines (03-rm), GAE under nonzero baselines plus the lambda=0 and
lambda=1 limits (04-ppo-gae), three-estimator KL comparison and per-token
reward shaping (04-ppo-kl), wrong-side ratio cases for the PPO clip plus
clipped value loss and entropy gradient (04-ppo-policy), tiny GPT-2
forward pass with causal mask diagram and Conv1D name-map slice (01-gpt2),
rollout tensor shapes and healthy-vs-reward-hacking log rows (05-ppo),
and a 5-row generation table, win-rate tally, and filled retrospective
(06-eval).